### PR TITLE
Adjust group implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4",
         "psr/http-factory": "^1.0",
-        "nyholm/psr7": "^1.0"
+        "nyholm/psr7": "^1.0",
+        "yiisoft/router-fastroute": "^3.0@dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/Group.php
+++ b/src/Group.php
@@ -21,6 +21,13 @@ class Group implements RouteCollectorInterface
         }
     }
 
+    final public static function create(?string $prefix, array $routes = [])
+    {
+        $factory = new GroupFactory();
+
+        return $factory($prefix, $routes);
+    }
+
     final public function addRoute(Route $route): void
     {
         $this->items[] = $route;
@@ -29,6 +36,11 @@ class Group implements RouteCollectorInterface
     final public function addGroup(string $prefix, callable $callback): void
     {
         $this->items[] = new Group($prefix, $callback);
+    }
+
+    final public function addGroupInstance(Group $group): void
+    {
+        $this->items[] = $group;
     }
 
     /**
@@ -45,7 +57,7 @@ class Group implements RouteCollectorInterface
             throw new InvalidArgumentException('Parameter should be either a PSR middleware or a callable.');
         }
 
-        $this->middlewares[] = $middleware;
+        array_unshift($this->middlewares, $middleware);
 
         return $this;
     }

--- a/src/GroupFactory.php
+++ b/src/GroupFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Yiisoft\Router;
+
+use InvalidArgumentException;
+
+final class GroupFactory
+{
+    public function __invoke(?string $prefix = null, array $routes = []): Group
+    {
+        $group = new Group($prefix, function (RouteCollectorInterface $collector) use ($routes) {
+            foreach ($routes as $route) {
+                if ($route instanceof Route) {
+                    $collector->addRoute($route);
+                } elseif ($route instanceof Group) {
+                    $collector->addGroupInstance($route);
+                } elseif (is_array($route) && count($route) === 2 && is_string($route[0]) && is_callable($route[1])) {
+                    $collector->addGroup($route[0], $route[1]);
+                } else {
+                    throw new InvalidArgumentException('Routes should be either instances of Route or Group or group arrays');
+                }
+            }
+        });
+
+        return $group;
+    }
+}

--- a/src/Route.php
+++ b/src/Route.php
@@ -193,7 +193,6 @@ final class Route implements MiddlewareInterface
      * ```
      * function (ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface {
      * ```
-     *     * Last added middleware will be invoked first.
      *
      * @param MiddlewareInterface|callable $middleware
      * @return Route

--- a/src/RouteCollectorInterface.php
+++ b/src/RouteCollectorInterface.php
@@ -15,14 +15,30 @@ interface RouteCollectorInterface
      * Add a prefix for a group of routes
      *
      * ```php
-     * $router->addGroup('/api', function (RouteCollectorInterface $router) {
-     *     $router->addRoute(...);
-     *     $router->addGroup(...);
-     * })->addMiddleware($myMiddleware);
+     * $router->addGroup('/api', function (Group $group) {
+     *     $group->addRoute(Route::get('/users', function () {}));
+     *     $group->addGroup(Route::get('/contacts', function () {}));
+     *     $group->addMiddleware($myMiddleware);
+     * });
      * ```
      *
      * @param string $prefix
      * @param callable $callback
      */
     public function addGroup(string $prefix, callable $callback): void;
+
+    /**
+     * Add a group of routes
+     *
+     * ```php
+     * $group = Group::create('/api', [
+     *     Route::get('/users', function () {}),
+     *     Route::get('/contacts', function () {}),
+     * ])->addMiddleware($myMiddleware);
+     * $router->addGroupInstance($group);
+     * ```
+     *
+     * @param Group $group
+     */
+    public function addGroupInstance(Group $group): void;
 }

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -30,6 +30,8 @@ final class RouterFactory
         foreach ($this->routes as $route) {
             if ($route instanceof Route) {
                 $router->addRoute($route);
+            } elseif ($route instanceof Group) {
+                $router->addGroupInstance($route);
             } elseif (is_array($route) && count($route) === 2 && is_string($route[0]) && is_callable($route[1])) {
                 $router->addGroup($route[0], $route[1]);
             } else {

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -2,10 +2,18 @@
 
 namespace Yiisoft\Router\Tests;
 
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Router\FastRoute\FastRouteFactory;
+use Yiisoft\Router\Middleware\Callback;
 use Yiisoft\Router\Group;
 use Yiisoft\Router\Route;
+use Yiisoft\Router\RouteCollectorInterface;
 
 class GroupTest extends TestCase
 {
@@ -35,8 +43,58 @@ class GroupTest extends TestCase
             ->addMiddleware($middleware2);
 
         $this->assertCount(2, $group->getMiddlewares());
-        $this->assertSame($middleware1, $group->getMiddlewares()[0]);
-        $this->assertSame($middleware2, $group->getMiddlewares()[1]);
+        $this->assertSame($middleware1, $group->getMiddlewares()[1]);
+        $this->assertSame($middleware2, $group->getMiddlewares()[0]);
+    }
+
+    public function testGroupMiddlewareFullStackCalled(): void
+    {
+        $factory = new FastRouteFactory();
+        $router = $factory();
+        $group = new Group('/group', function (RouteCollectorInterface $r) {
+            $r->addRoute(Route::get('/test1')->name('request1'));
+        });
+
+        $request = new ServerRequest('GET', '/group/test1');
+        $middleware1 = new Callback(function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
+            $request = $request->withAttribute('middleware', 'middleware1');
+            return $handler->handle($request);
+        });
+        $middleware2 = new Callback(function (ServerRequestInterface $request) {
+            return new Response(200, [], null, '1.1', implode($request->getAttributes()));
+        });
+
+        $group->addMiddleware($middleware2)->addMiddleware($middleware1);
+
+        $router->addGroupInstance($group);
+        $result = $router->match($request);
+        $response = $result->process($request, $this->getRequestHandler());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('middleware1', $response->getReasonPhrase());
+    }
+
+    public function testGroupMiddlewareStackInterrupted(): void
+    {
+        $factory = new FastRouteFactory();
+        $router = $factory();
+        $group = new Group('/group', function (RouteCollectorInterface $r) {
+            $r->addRoute(Route::get('/test1')->name('request1'));
+        });
+
+        $request = new ServerRequest('GET', '/group/test1');
+        $middleware1 = new Callback(function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
+            return new Response(403);
+        });
+        $middleware2 = new Callback(function (ServerRequestInterface $request) {
+            return new Response(200);
+        });
+
+        $group->addMiddleware($middleware2)->addMiddleware($middleware1);
+
+        $router->addGroupInstance($group);
+        $result = $router->match($request);
+        $response = $result->process($request, $this->getRequestHandler());
+        $this->assertSame(403, $response->getStatusCode());
     }
 
     public function testAddGroup(): void
@@ -71,13 +129,63 @@ class GroupTest extends TestCase
         $postGroup = $api->getItems()[1];
         $this->assertInstanceOf(Group::class, $postGroup);
         $this->assertCount(2, $api->getMiddlewares());
-        $this->assertSame($middleware1, $api->getMiddlewares()[0]);
-        $this->assertSame($middleware2, $api->getMiddlewares()[1]);
+        $this->assertSame($middleware1, $api->getMiddlewares()[1]);
+        $this->assertSame($middleware2, $api->getMiddlewares()[0]);
 
         $this->assertSame('/post', $postGroup->getPrefix());
         $this->assertCount(2, $postGroup->getItems());
         $this->assertSame($listRoute, $postGroup->getItems()[0]);
         $this->assertSame($viewRoute, $postGroup->getItems()[1]);
         $this->assertEmpty($postGroup->getMiddlewares());
+    }
+
+    public function testAddGroupSecondWay(): void
+    {
+        $logoutRoute = Route::post('/logout');
+        $listRoute = Route::get('/');
+        $viewRoute = Route::get('/{id}');
+
+        $middleware1 = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
+        $middleware2 = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
+
+        $root = Group::create(null, [
+            Group::create('/api', [
+                $logoutRoute,
+                Group::create('/post', [
+                    $listRoute,
+                    $viewRoute
+                ])
+            ])->addMiddleware($middleware1)->addMiddleware($middleware2)
+        ]);
+
+        $this->assertCount(1, $root->getItems());
+        $api = $root->getItems()[0];
+
+        $this->assertSame('/api', $api->getPrefix());
+        $this->assertCount(2, $api->getItems());
+        $this->assertSame($logoutRoute, $api->getItems()[0]);
+
+        /** @var Group $postGroup */
+        $postGroup = $api->getItems()[1];
+        $this->assertInstanceOf(Group::class, $postGroup);
+        $this->assertCount(2, $api->getMiddlewares());
+        $this->assertSame($middleware1, $api->getMiddlewares()[1]);
+        $this->assertSame($middleware2, $api->getMiddlewares()[0]);
+
+        $this->assertSame('/post', $postGroup->getPrefix());
+        $this->assertCount(2, $postGroup->getItems());
+        $this->assertSame($listRoute, $postGroup->getItems()[0]);
+        $this->assertSame($viewRoute, $postGroup->getItems()[1]);
+        $this->assertEmpty($postGroup->getMiddlewares());
+    }
+
+    private function getRequestHandler(): RequestHandlerInterface
+    {
+        return new class() implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(404);
+            }
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

This is a little bit better implementation of the Group class.
I had to add router-fastroute as a dev-dependency, but I don't like it.
I don't like that one part of the Group middleware implementation is in the Group class while another part is in the FastRoute class. It seems to me this is a very bad idea. It should be implemented inside the Group class completely. What do you think?

And now is the time to talk about pleasant. We have a new alternative group syntaxis. It is simpler and more flexible. 

The current syntax
```php
$routes = [
    Route::get('/', new ActionCaller(SiteController::class, 'index', $container)),
    ['/blog', function (Group $group) use ($container, $middleware1, $middleware2) {
        $group->addRoute(Route::get('/login', new ActionCaller(BlogController::class, 'login', $container)));
        $group->addGroup('/post', function (Group $group) use ($container) {
            $group->addRoute(Route::get('/index', new ActionCaller(PostController::class, 'index', $container)));
            $group->addRoute(Route::get('/view', new ActionCaller(PostController::class, 'view', $container)));
        });
        $group->addMiddleware($middleware1)->addMiddleware($middleware2);
    }],
]
```
the new alternative syntax
```php
$routes = [
    Route::get('/', new ActionCaller(SiteController::class, 'index', $container)),
    Group::create('/blog', [
        Route::get('/login', new ActionCaller(BlogController::class, 'login', $container)),
        Group::create('/post', [
            Route::get('/index', new ActionCaller(PostController::class, 'index', $container)),
            Route::get('/view', new ActionCaller(PostController::class, 'view', $container)),
         ])
    ])->addMiddleware($middleware1)->addMiddleware($middleware2),
]
```
I'm working on a yii3 module system now and that's what I need, the flexible way to build routes dinamically.