### PR TITLE
Add middleware lazy loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "yiisoft/http": "1.0.x-dev",
-        "yiisoft/injector" : "^3.0@dev"
+        "yiisoft/injector": "^3.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "yiisoft/http": "1.0.x-dev"
+        "yiisoft/http": "1.0.x-dev",
+        "yiisoft/injector" : "^3.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/src/Group.php
+++ b/src/Group.php
@@ -3,6 +3,7 @@
 namespace Yiisoft\Router;
 
 use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Yiisoft\Router\Middleware\Callback;
 
@@ -11,9 +12,11 @@ class Group implements RouteCollectorInterface
     protected array $items = [];
     protected ?string $prefix;
     protected array $middlewares = [];
+    private ?ContainerInterface $container;
 
-    public function __construct(?string $prefix = null, ?callable $callback = null)
+    public function __construct(?string $prefix = null, ?callable $callback = null, ContainerInterface $container = null)
     {
+        $this->container = $container;
         $this->prefix = $prefix;
 
         if ($callback !== null) {
@@ -21,9 +24,9 @@ class Group implements RouteCollectorInterface
         }
     }
 
-    final public static function create(?string $prefix, array $routes = [])
+    final public static function create(?string $prefix, array $routes = [], ContainerInterface $container = null)
     {
-        $factory = new GroupFactory();
+        $factory = new GroupFactory($container);
 
         return $factory($prefix, $routes);
     }
@@ -50,7 +53,7 @@ class Group implements RouteCollectorInterface
     final public function addMiddleware($middleware): self
     {
         if (is_callable($middleware)) {
-            $middleware = new Callback($middleware);
+            $middleware = new Callback($middleware, $this->container);
         }
 
         if (!$middleware instanceof MiddlewareInterface) {

--- a/src/Group.php
+++ b/src/Group.php
@@ -33,6 +33,9 @@ class Group implements RouteCollectorInterface
 
     final public function addRoute(Route $route): void
     {
+        if (!$route->hasContainer() && $this->container !== null) {
+            $route = $route->setContainer($this->container);
+        }
         $this->items[] = $route;
     }
 

--- a/src/GroupFactory.php
+++ b/src/GroupFactory.php
@@ -3,9 +3,17 @@
 namespace Yiisoft\Router;
 
 use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
 
 final class GroupFactory
 {
+    private $container;
+
+    public function __construct(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
     public function __invoke(?string $prefix = null, array $routes = []): Group
     {
         $group = new Group($prefix, function (RouteCollectorInterface $collector) use ($routes) {
@@ -20,7 +28,7 @@ final class GroupFactory
                     throw new InvalidArgumentException('Routes should be either instances of Route or Group or group arrays');
                 }
             }
-        });
+        }, $this->container);
 
         return $group;
     }

--- a/src/Middleware/ActionCaller.php
+++ b/src/Middleware/ActionCaller.php
@@ -17,8 +17,8 @@ use Yiisoft\Injector\Injector;
  */
 final class ActionCaller implements MiddlewareInterface
 {
-    private $class;
-    private $method;
+    private string $class;
+    private string $method;
     private ContainerInterface $container;
 
     public function __construct(string $class, string $method, ContainerInterface $container)

--- a/src/Middleware/ActionCaller.php
+++ b/src/Middleware/ActionCaller.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Yiisoft\Router\Middleware;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Injector\Injector;
+
+/**
+ * ActionCaller maps a route to specified class instance and method.
+ *
+ * Dependencies are automatically injected into both method
+ * and constructor based on types specified.
+ */
+final class ActionCaller implements MiddlewareInterface
+{
+    private $class;
+    private $method;
+    private $container;
+
+    public function __construct(string $class, string $method, ContainerInterface $container)
+    {
+        $this->class = $class;
+        $this->method = $method;
+        $this->container = $container;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $controller = $this->container->get($this->class);
+        $response = (new Injector($this->container))->invoke([$controller, $this->method], [$request, $handler]);
+        $handler->handle($request);
+        return $response;
+    }
+}

--- a/src/Middleware/ActionCaller.php
+++ b/src/Middleware/ActionCaller.php
@@ -31,8 +31,6 @@ final class ActionCaller implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $controller = $this->container->get($this->class);
-        $response = (new Injector($this->container))->invoke([$controller, $this->method], [$request, $handler]);
-        $handler->handle($request);
-        return $response;
+        return (new Injector($this->container))->invoke([$controller, $this->method], [$request, $handler]);
     }
 }

--- a/src/Middleware/ActionCaller.php
+++ b/src/Middleware/ActionCaller.php
@@ -19,7 +19,7 @@ final class ActionCaller implements MiddlewareInterface
 {
     private $class;
     private $method;
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(string $class, string $method, ContainerInterface $container)
     {

--- a/src/Middleware/Callback.php
+++ b/src/Middleware/Callback.php
@@ -2,24 +2,29 @@
 
 namespace Yiisoft\Router\Middleware;
 
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Yiisoft\Injector\Injector;
 
+/**
+ * Callback wraps arbitrary PHP callback into object matching {@see MiddlewareInterface}.
+ */
 final class Callback implements MiddlewareInterface
 {
     private $callback;
+    private ContainerInterface $container;
 
-    public function __construct(callable $callback)
+    public function __construct(callable $callback, ContainerInterface $container)
     {
         $this->callback = $callback;
+        $this->container = $container;
     }
 
-    public function process(
-        ServerRequestInterface $request,
-        RequestHandlerInterface $handler
-    ): ResponseInterface {
-        return \call_user_func($this->callback, $request, $handler);
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return (new Injector($this->container))->invoke($this->callback, [$request, $handler]);
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -229,7 +229,7 @@ final class Route implements MiddlewareInterface
             return $this->container->get($middleware);
         }
 
-        if (is_array($middleware)) {
+        if (is_array($middleware) && !is_object($middleware[0])) {
             return new ActionCaller($middleware[0], $middleware[1], $this->container);
         }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -41,6 +41,18 @@ final class Route implements MiddlewareInterface
         $this->container = $container;
     }
 
+    public function setContainer(ContainerInterface $container)
+    {
+        $route = clone $this;
+        $route->container = $container;
+        return $route;
+    }
+
+    public function hasContainer()
+    {
+        return $this->container !== null;
+    }
+
     /**
      * @param string $pattern
      * @param MiddlewareInterface|callable|string|array|null $middleware primary route handler {@see addMiddleware()}
@@ -190,9 +202,6 @@ final class Route implements MiddlewareInterface
         if (
             is_string($middleware) && is_subclass_of($middleware, MiddlewareInterface::class)
         ) {
-            if ($this->container === null) {
-                throw new InvalidArgumentException('Route container must not be null for lazy loaded middleware.');
-            }
             return;
         }
 
@@ -201,16 +210,10 @@ final class Route implements MiddlewareInterface
             && isset($middleware[0], $middleware[1])
             && is_string($middleware[1]) && is_string($middleware[0]) && class_exists($middleware[0])
         ) {
-            if ($this->container === null) {
-                throw new InvalidArgumentException('Route container must not be null for handler action.');
-            }
             return;
         }
 
         if (is_callable($middleware)) {
-            if ($this->container === null) {
-                throw new InvalidArgumentException('Route container must not be null for callable.');
-            }
             return;
         }
 
@@ -226,14 +229,23 @@ final class Route implements MiddlewareInterface
     private function prepareMiddleware($middleware)
     {
         if (is_string($middleware)) {
+            if ($this->container === null) {
+                throw new InvalidArgumentException('Route container must not be null for lazy loaded middleware.');
+            }
             return $this->container->get($middleware);
         }
 
         if (is_array($middleware) && !is_object($middleware[0])) {
+            if ($this->container === null) {
+                throw new InvalidArgumentException('Route container must not be null for handler action.');
+            }
             return new ActionCaller($middleware[0], $middleware[1], $this->container);
         }
 
         if (is_callable($middleware)) {
+            if ($this->container === null) {
+                throw new InvalidArgumentException('Route container must not be null for callable.');
+            }
             return new Callback($middleware, $this->container);
         }
 

--- a/src/Route.php
+++ b/src/Route.php
@@ -44,6 +44,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function get(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -54,6 +55,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function post(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -74,6 +76,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function delete(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -84,6 +87,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function patch(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -94,6 +98,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function head(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -104,6 +109,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function options(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -115,6 +121,7 @@ final class Route implements MiddlewareInterface
      * @param array $methods
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function methods(array $methods, string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -131,6 +138,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param string $pattern
      * @param callable|MiddlewareInterface|null $middleware
+     * @param ContainerInterface $container
      * @return static
      */
     public static function anyMethod(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
@@ -203,7 +211,7 @@ final class Route implements MiddlewareInterface
         }
 
         if (!$middleware instanceof MiddlewareInterface) {
-            throw new InvalidArgumentException('Parameter should be either a PSR middleware or a callable.');
+            throw new InvalidArgumentException('Parameter should be either a PSR middleware or a callable or a middleware class name.');
         }
 
         return $middleware;

--- a/src/Route.php
+++ b/src/Route.php
@@ -22,7 +22,7 @@ final class Route implements MiddlewareInterface
     private array $methods;
     private string $pattern;
     private ?string $host = null;
-    private $container;
+    private ?ContainerInterface $container;
     /**
      * Contains a chain of middleware wrapped in handlers.
      * Each handler points to the handler of middleware that will be processed next.
@@ -46,7 +46,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function get(string $pattern, $middleware = null, $container = null): self
+    public static function get(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::GET], $pattern, $middleware, $container);
     }
@@ -56,7 +56,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function post(string $pattern, $middleware = null, $container = null): self
+    public static function post(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::POST], $pattern, $middleware, $container);
     }
@@ -66,7 +66,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function put(string $pattern, $middleware = null, $container = null): self
+    public static function put(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::PUT], $pattern, $middleware, $container);
     }
@@ -76,7 +76,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function delete(string $pattern, $middleware = null, $container = null): self
+    public static function delete(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::DELETE], $pattern, $middleware, $container);
     }
@@ -86,7 +86,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function patch(string $pattern, $middleware = null, $container = null): self
+    public static function patch(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::PATCH], $pattern, $middleware, $container);
     }
@@ -96,7 +96,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function head(string $pattern, $middleware = null, $container = null): self
+    public static function head(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::HEAD], $pattern, $middleware, $container);
     }
@@ -106,7 +106,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function options(string $pattern, $middleware = null, $container = null): self
+    public static function options(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods([Method::OPTIONS], $pattern, $middleware, $container);
     }
@@ -117,7 +117,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function methods(array $methods, string $pattern, $middleware = null, $container = null): self
+    public static function methods(array $methods, string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         $route = new static($container);
         $route->methods = $methods;
@@ -133,7 +133,7 @@ final class Route implements MiddlewareInterface
      * @param callable|MiddlewareInterface|null $middleware
      * @return static
      */
-    public static function anyMethod(string $pattern, $middleware = null, $container = null): self
+    public static function anyMethod(string $pattern, $middleware = null, ?ContainerInterface $container = null): self
     {
         return static::methods(Method::ANY, $pattern, $middleware, $container);
     }
@@ -179,8 +179,7 @@ final class Route implements MiddlewareInterface
     private function prepareMiddleware($middleware)
     {
         if (
-            is_string($middleware) && class_exists($middleware)
-            && in_array(MiddlewareInterface::class, class_implements($middleware))
+            is_string($middleware) && is_subclass_of($middleware, MiddlewareInterface::class)
         ) {
             if ($this->container === null) {
                 throw new InvalidArgumentException('Route container must not be null for lazy loaded middleware.');
@@ -190,7 +189,7 @@ final class Route implements MiddlewareInterface
 
         if (
             is_array($middleware) && count($middleware) === 2
-            && isset($middleware[0]) && isset($middleware[1])
+            && isset($middleware[0], $middleware[1])
             && is_string($middleware[1]) && is_string($middleware[0]) && class_exists($middleware[0])
         ) {
             if ($this->container === null) {

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -29,6 +29,9 @@ final class RouterFactory
         $router = $factory();
         foreach ($this->routes as $route) {
             if ($route instanceof Route) {
+                if (!$route->hasContainer()) {
+                    $route = $route->setContainer($container);
+                }
                 $router->addRoute($route);
             } elseif ($route instanceof Group) {
                 $router->addGroupInstance($route);

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -5,6 +5,7 @@ namespace Yiisoft\Router\Tests;
 use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -14,6 +15,7 @@ use Yiisoft\Router\Middleware\Callback;
 use Yiisoft\Router\Group;
 use Yiisoft\Router\Route;
 use Yiisoft\Router\RouteCollectorInterface;
+use Yiisoft\Router\Tests\Support\Container;
 
 class GroupTest extends TestCase
 {
@@ -59,10 +61,10 @@ class GroupTest extends TestCase
         $middleware1 = new Callback(function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             $request = $request->withAttribute('middleware', 'middleware1');
             return $handler->handle($request);
-        });
+        }, $this->getContainer());
         $middleware2 = new Callback(function (ServerRequestInterface $request) {
             return new Response(200, [], null, '1.1', implode($request->getAttributes()));
-        });
+        }, $this->getContainer());
 
         $group->addMiddleware($middleware2)->addMiddleware($middleware1);
 
@@ -84,10 +86,10 @@ class GroupTest extends TestCase
         $request = new ServerRequest('GET', '/group/test1');
         $middleware1 = new Callback(function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             return new Response(403);
-        });
+        }, $this->getContainer());
         $middleware2 = new Callback(function (ServerRequestInterface $request) {
             return new Response(200);
-        });
+        }, $this->getContainer());
 
         $group->addMiddleware($middleware2)->addMiddleware($middleware1);
 
@@ -187,5 +189,10 @@ class GroupTest extends TestCase
                 return new Response(404);
             }
         };
+    }
+
+    private function getContainer(array $instances = []): ContainerInterface
+    {
+        return new Container($instances);
     }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -181,6 +181,17 @@ final class RouteTest extends TestCase
         $this->assertSame(418, $response->getStatusCode());
     }
 
+    public function testAddCallableArrayMiddleware(): void
+    {
+        $request = new ServerRequest('GET', '/');
+
+        $controller = new TestController();
+        $route = Route::get('/', null, $this->getContainer())->addMiddleware([$controller, 'index']);
+
+        $response = $route->process($request, $this->getRequestHandler());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     public function testMiddlewareFullStackCalled(): void
     {
         $container = $this->getContainer();

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -228,7 +228,7 @@ final class RouteTest extends TestCase
     public function testInvalidMiddlewareAddWrongStringClassLL()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Parameter should be either a PSR middleware or a callable.');
+        $this->expectExceptionMessage('Parameter should be either a PSR middleware or a callable or a middleware class name.');
         Route::get('/', TestController::class);
     }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -247,13 +247,6 @@ final class RouteTest extends TestCase
         Route::get('/', TestController::class);
     }
 
-    public function testInvalidMiddlewareAddWrongStringContainerLL(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Route container must not be null for lazy loaded middleware.');
-        Route::get('/', TestMiddleware::class);
-    }
-
     public function testMiddlewareAddSuccessStringLL(): void
     {
         $route = Route::get('/', TestMiddleware::class, $this->getContainer());
@@ -278,13 +271,6 @@ final class RouteTest extends TestCase
         Route::get('/', ['class' => TestController::class, 'index']);
     }
 
-    public function testInvalidMiddlewareAddWrongArrayContainerLL(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Route container must not be null for handler action.');
-        Route::get('/', [TestController::class, 'index']);
-    }
-
     public function testMiddlewareAddSuccessArrayLL(): void
     {
         $route = Route::get('/', [TestController::class, 'index'], $this->getContainer());
@@ -298,6 +284,18 @@ final class RouteTest extends TestCase
             TestController::class => new TestController(),
         ]);
         $route = Route::get('/', [TestController::class, 'index'], $container);
+        $response = $route->process($request, $this->getRequestHandler());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testMiddlewareCallSuccessArrayWithoutContainerLL(): void
+    {
+        $request = new ServerRequest('GET', '/');
+        $container = $this->getContainer([
+            TestController::class => new TestController(),
+        ]);
+        $route = Route::get('/', [TestController::class, 'index']);
+        $route = $route->setContainer($container);
         $response = $route->process($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
     }

--- a/tests/Support/Container.php
+++ b/tests/Support/Container.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace Yiisoft\Router\Tests\Support;
+
+
+use Psr\Container\ContainerInterface;
+
+class Container implements ContainerInterface
+{
+    private array $instances;
+
+    public function __construct(array $instances)
+    {
+        $this->instances = $instances;
+    }
+
+    public function get($id)
+    {
+        if ($this->has($id)) {
+            return $this->instances[$id];
+        }
+
+        throw new NotFoundException("$id was not found in container");
+    }
+
+    public function has($id)
+    {
+        return array_key_exists($id, $this->instances);
+    }
+}

--- a/tests/Support/Container.php
+++ b/tests/Support/Container.php
@@ -3,7 +3,6 @@
 
 namespace Yiisoft\Router\Tests\Support;
 
-
 use Psr\Container\ContainerInterface;
 
 class Container implements ContainerInterface

--- a/tests/Support/NotFoundException.php
+++ b/tests/Support/NotFoundException.php
@@ -3,7 +3,6 @@
 
 namespace Yiisoft\Router\Tests\Support;
 
-
 use Psr\Container\NotFoundExceptionInterface;
 
 class NotFoundException extends \RuntimeException implements NotFoundExceptionInterface

--- a/tests/Support/NotFoundException.php
+++ b/tests/Support/NotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Yiisoft\Router\Tests\Support;
+
+
+use Psr\Container\NotFoundExceptionInterface;
+
+class NotFoundException extends \RuntimeException implements NotFoundExceptionInterface
+{
+
+}

--- a/tests/Support/TestController.php
+++ b/tests/Support/TestController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Yiisoft\Router\Tests\Support;
+
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * ETestController
+ */
+class TestController
+{
+    /**
+     * @return string
+     */
+    public function index(): ResponseInterface
+    {
+        return new Response();
+    }
+}

--- a/tests/Support/TestMiddleware.php
+++ b/tests/Support/TestMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Yiisoft\Router\Tests\Support;
+
+use Nyholm\Psr7\Response;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * TestMiddleware
+ */
+class TestMiddleware implements MiddlewareInterface
+{
+    /**
+     * @return string
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return new Response();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Ladies and gentlemen, I'm pleased to present you the lazy loading of middlewares.
For now and forever we have a very fast and light router. All middlewares (controller action is included) can be loaded directly before the Route middleware stack will be executed. It means that the middlewares attached this way will be created after the Router matches the route.

Examples of usage:
```php
$routes = [
   Route::get('/', [SiteController::class, 'index'], $container),
       ->addMiddleware(SomeMiddleware::class),
   Route::get('export', ExportMiddleware::class, $container),
];
```
