### PR TITLE
Fix Typed property Yiisoft\Router\Group::$container must not be acces…

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -12,7 +12,7 @@ class Group implements RouteCollectorInterface
     protected array $items = [];
     protected ?string $prefix;
     protected array $middlewares = [];
-    private ?ContainerInterface $container;
+    private ?ContainerInterface $container = null;
 
     public function __construct(?string $prefix = null, ?callable $callback = null, ContainerInterface $container = null)
     {

--- a/src/GroupFactory.php
+++ b/src/GroupFactory.php
@@ -7,7 +7,7 @@ use Psr\Container\ContainerInterface;
 
 final class GroupFactory
 {
-    private $container;
+    private ?ContainerInterface $container = null;
 
     public function __construct(ContainerInterface $container = null)
     {

--- a/src/Route.php
+++ b/src/Route.php
@@ -36,7 +36,7 @@ final class Route implements MiddlewareInterface
     private array $middlewares = [];
     private array $defaults = [];
 
-    private function __construct(?ContainerInterface $container)
+    private function __construct(?ContainerInterface $container = null)
     {
         $this->container = $container;
     }

--- a/src/Route.php
+++ b/src/Route.php
@@ -22,7 +22,7 @@ final class Route implements MiddlewareInterface
     private array $methods;
     private string $pattern;
     private ?string $host = null;
-    private ?ContainerInterface $container;
+    private ?ContainerInterface $container = null;
     /**
      * Contains a chain of middleware wrapped in handlers.
      * Each handler points to the handler of middleware that will be processed next.


### PR DESCRIPTION
Typed property `Yiisoft\Router\Group::$container` must not be accessed before
initialization

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  |