### PR TITLE
Remove unnecessary condition

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -205,14 +205,6 @@ final class Route implements MiddlewareInterface
             return;
         }
 
-        if (
-            is_array($middleware) && count($middleware) === 2
-            && isset($middleware[0], $middleware[1])
-            && is_string($middleware[1]) && is_string($middleware[0]) && class_exists($middleware[0])
-        ) {
-            return;
-        }
-
         if (is_callable($middleware)) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

This check is not necessary now, because is_callable() checks that this is the array with two elements where first is a class name or an object and second is the class method name. 
