### PR TITLE
Add container late binding

### DIFF
--- a/src/MatchingResult.php
+++ b/src/MatchingResult.php
@@ -2,6 +2,7 @@
 
 namespace Yiisoft\Router;
 
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -14,9 +15,15 @@ final class MatchingResult implements MiddlewareInterface
     private Route $route;
     private array $parameters = [];
     private array $methods = [];
+    private ?ContainerInterface $container = null;
 
     private function __construct()
     {
+    }
+
+    public function setContainer(ContainerInterface $container): void
+    {
+        $this->container = $container;
     }
 
     public static function fromSuccess(Route $route, array $parameters): self
@@ -61,7 +68,11 @@ final class MatchingResult implements MiddlewareInterface
         if ($this->success === false) {
             return $handler->handle($request);
         }
+        $route = $this->route;
+        if ($this->container !== null && !$route->hasContainer()) {
+            $route = $route->withContainer($this->container);
+        }
 
-        return $this->route->process($request, $handler);
+        return $route->process($request, $handler);
     }
 }

--- a/src/MatchingResult.php
+++ b/src/MatchingResult.php
@@ -21,9 +21,11 @@ final class MatchingResult implements MiddlewareInterface
     {
     }
 
-    public function setContainer(ContainerInterface $container): void
+    public function withContainer(ContainerInterface $container): self
     {
-        $this->container = $container;
+        $new = clone $this;
+        $new->container = $container;
+        return $new;
     }
 
     public static function fromSuccess(Route $route, array $parameters): self

--- a/src/Middleware/Router.php
+++ b/src/Middleware/Router.php
@@ -39,8 +39,7 @@ final class Router implements MiddlewareInterface
         foreach ($result->parameters() as $parameter => $value) {
             $request = $request->withAttribute($parameter, $value);
         }
-        $result->setContainer($this->container);
 
-        return $result->process($request, $handler);
+        return $result->withContainer($this->container)->process($request, $handler);
     }
 }

--- a/src/Middleware/Router.php
+++ b/src/Middleware/Router.php
@@ -2,6 +2,7 @@
 
 namespace Yiisoft\Router\Middleware;
 
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -13,11 +14,13 @@ final class Router implements MiddlewareInterface
 {
     private UrlMatcherInterface $matcher;
     private ResponseFactoryInterface $responseFactory;
+    private ContainerInterface $container;
 
-    public function __construct(UrlMatcherInterface $matcher, ResponseFactoryInterface $responseFactory)
+    public function __construct(UrlMatcherInterface $matcher, ResponseFactoryInterface $responseFactory, ContainerInterface $container)
     {
         $this->matcher = $matcher;
         $this->responseFactory = $responseFactory;
+        $this->container = $container;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -36,6 +39,7 @@ final class Router implements MiddlewareInterface
         foreach ($result->parameters() as $parameter => $value) {
             $request = $request->withAttribute($parameter, $value);
         }
+        $result->setContainer($this->container);
 
         return $result->process($request, $handler);
     }

--- a/tests/Middleware/RouterTest.php
+++ b/tests/Middleware/RouterTest.php
@@ -6,6 +6,7 @@ use Nyholm\Psr7\Response;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -23,7 +24,8 @@ final class RouterTest extends TestCase
 {
     private function createRouterMiddleware(): Router
     {
-        return new Router($this->getMatcher(), new Psr17Factory());
+        $container = $this->createMock(ContainerInterface::class);
+        return new Router($this->getMatcher(), new Psr17Factory(), $container);
     }
 
     private function processWithRouter(ServerRequestInterface $request): ResponseInterface


### PR DESCRIPTION
| Q                 | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️


Added container late binding/injecting. Just replace `RouteCollectorInterface::class => new GroupFactory()` with `RouteCollectorInterface::class => new Group()` in the your container config and the container will be injected into Route immediately before processing.
