### PR TITLE
Rename method addMiddleware to withMiddleware

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -128,7 +128,7 @@ final class Group implements RouteCollectorInterface
      * @param callable|MiddlewareInterface $middleware
      * @return $this
      */
-    final public function addMiddleware($middleware): self
+    final public function withMiddleware($middleware): self
     {
         $this->validateMiddleware($middleware);
         $this->middlewares[] = $middleware;

--- a/src/Group.php
+++ b/src/Group.php
@@ -131,9 +131,10 @@ final class Group implements RouteCollectorInterface
     final public function withMiddleware($middleware): self
     {
         $this->validateMiddleware($middleware);
-        $this->middlewares[] = $middleware;
+        $new = clone $this;
+        $new->middlewares[] = $middleware;
 
-        return $this;
+        return $new;
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -54,7 +54,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface $container|null
      * @return self
      */
@@ -65,7 +65,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -76,7 +76,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -87,7 +87,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -98,7 +98,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -109,7 +109,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -120,7 +120,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -132,7 +132,7 @@ final class Route implements MiddlewareInterface
     /**
      * @param array $methods
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -150,7 +150,7 @@ final class Route implements MiddlewareInterface
 
     /**
      * @param string $pattern
-     * @param callable|string|array|null $middleware primary route handler {@see addMiddleware()}
+     * @param callable|string|array|null $middleware primary route handler {@see withMiddleware()}
      * @param ContainerInterface|null $container
      * @return self
      */
@@ -264,7 +264,7 @@ final class Route implements MiddlewareInterface
      * @param callable|string|array $middleware
      * @return Route
      */
-    public function addMiddleware($middleware): self
+    public function withMiddleware($middleware): self
     {
         $this->validateMiddleware($middleware);
 

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -117,7 +117,7 @@ final class RouteCollection implements RouteCollectionInterface
         foreach ($items as $index => $item) {
             $groupMiddlewares = $group->getMiddlewares();
             foreach ($groupMiddlewares as $middleware) {
-                $item = $item->addMiddleware($middleware);
+                $item = $item->withMiddleware($middleware);
             }
 
             if ($item instanceof Group) {

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -112,7 +112,6 @@ final class RouteCollection implements RouteCollectionInterface
     private function injectGroup(Group $group, array &$tree, string $prefix = ''): void
     {
         $prefix .= $group->getPrefix();
-        /** @var $items Group[]|Route[] */
         $items = $group->getItems();
         foreach ($items as $index => $item) {
             $groupMiddlewares = $group->getMiddlewares();

--- a/src/RouteCollectorInterface.php
+++ b/src/RouteCollectorInterface.php
@@ -42,7 +42,7 @@ interface RouteCollectorInterface
     public function hasContainer(): bool;
 
     /**
-     * @return Route|Group[]
+     * @return Route[]|Group[]
      */
     public function getItems(): array;
 }

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -2,11 +2,10 @@
 
 namespace Yiisoft\Router\Tests;
 
-use Nyholm\Psr7\ServerRequest;
 use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -44,8 +43,8 @@ class GroupTest extends TestCase
         };
 
         $group
-            ->addMiddleware($middleware1)
-            ->addMiddleware($middleware2);
+            ->withMiddleware($middleware1)
+            ->withMiddleware($middleware2);
 
         $this->assertCount(2, $group->getMiddlewares());
         $this->assertSame($middleware1, $group->getMiddlewares()[0]);
@@ -68,8 +67,8 @@ class GroupTest extends TestCase
         $group = Group::create('/outergroup', [
             Group::create('/innergroup', [
                 Route::get('/test1')->name('request1')
-            ])->addMiddleware($middleware2),
-        ], $this->getContainer())->addMiddleware($middleware1);
+            ])->withMiddleware($middleware2),
+        ], $this->getContainer())->withMiddleware($middleware1);
 
         $collector = Group::create();
         $collector->addGroup($group);
@@ -96,7 +95,7 @@ class GroupTest extends TestCase
             return new Response(200, [], null, '1.1', implode($request->getAttributes()));
         };
 
-        $group->addMiddleware($middleware2)->addMiddleware($middleware1);
+        $group->withMiddleware($middleware2)->withMiddleware($middleware1);
         $collector = Group::create();
         $collector->addGroup($group);
 
@@ -121,7 +120,7 @@ class GroupTest extends TestCase
             return new Response(200);
         };
 
-        $group->addMiddleware($middleware2)->addMiddleware($middleware1);
+        $group->withMiddleware($middleware2)->withMiddleware($middleware1);
         $collector = Group::create();
         $collector->addGroup($group);
 
@@ -152,8 +151,8 @@ class GroupTest extends TestCase
                 $group->addRoute($viewRoute);
             }));
 
-            $group->addMiddleware($middleware1);
-            $group->addMiddleware($middleware2);
+            $group->withMiddleware($middleware1);
+            $group->withMiddleware($middleware2);
         }));
 
         $this->assertCount(1, $root->getItems());
@@ -197,7 +196,7 @@ class GroupTest extends TestCase
                     $listRoute,
                     $viewRoute
                 ])
-            ])->addMiddleware($middleware1)->addMiddleware($middleware2)
+            ])->withMiddleware($middleware1)->withMiddleware($middleware2)
         ]);
 
         $this->assertCount(1, $root->getItems());

--- a/tests/MatchingResultTest.php
+++ b/tests/MatchingResultTest.php
@@ -45,7 +45,7 @@ final class MatchingResultTest extends TestCase
     public function testProcessSuccess(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $route = Route::post('/', null, $container)->addMiddleware($this->getMiddleware());
+        $route = Route::post('/', null, $container)->withMiddleware($this->getMiddleware());
         $result = MatchingResult::fromSuccess($route, []);
         $request = new ServerRequest('POST', '/');
 

--- a/tests/Middleware/RouterTest.php
+++ b/tests/Middleware/RouterTest.php
@@ -93,7 +93,7 @@ final class RouterTest extends TestCase
                 }
 
                 if ($request->getMethod() === 'GET') {
-                    $route = Route::get('/')->addMiddleware($this->middleware);
+                    $route = Route::get('/')->withMiddleware($this->middleware);
                     return MatchingResult::fromSuccess($route, ['parameter' => 'value']);
                 }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -143,7 +143,7 @@ final class RouteTest extends TestCase
     public function testInvalidMiddlewareAdd(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        Route::get('/')->addMiddleware(new \stdClass());
+        Route::get('/')->withMiddleware(new \stdClass());
     }
 
     public function testAddMiddleware(): void
@@ -151,7 +151,7 @@ final class RouteTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $request = new ServerRequest('GET', '/');
 
-        $route = Route::get('/', null, $container)->addMiddleware(
+        $route = Route::get('/', null, $container)->withMiddleware(
             function () {
                 return new Response(418);
             }
@@ -165,7 +165,7 @@ final class RouteTest extends TestCase
     {
         $request = new ServerRequest('GET', '/');
 
-        $route = Route::get('/', null, $this->getContainer())->addMiddleware(
+        $route = Route::get('/', null, $this->getContainer())->withMiddleware(
             static function (): ResponseInterface {
                 return (new Response())->withStatus(418);
             }
@@ -179,7 +179,7 @@ final class RouteTest extends TestCase
     {
         $request = new ServerRequest('GET', '/');
 
-        $route = Route::get('/', null, $this->getContainer([TestController::class => new TestController()]))->addMiddleware([TestController::class, 'index']);
+        $route = Route::get('/', null, $this->getContainer([TestController::class => new TestController()]))->withMiddleware([TestController::class, 'index']);
 
         $response = $route->process($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
@@ -200,7 +200,7 @@ final class RouteTest extends TestCase
             return new Response(200, [], null, '1.1', implode($request->getAttributes()));
         };
 
-        $routeOne = $routeOne->addMiddleware($middleware2)->addMiddleware($middleware1);
+        $routeOne = $routeOne->withMiddleware($middleware2)->withMiddleware($middleware1);
 
         $response = $routeOne->process($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
@@ -221,7 +221,7 @@ final class RouteTest extends TestCase
             return new Response(200);
         };
 
-        $routeTwo = $routeTwo->addMiddleware($middleware2)->addMiddleware($middleware1);
+        $routeTwo = $routeTwo->withMiddleware($middleware2)->withMiddleware($middleware1);
 
         $response = $routeTwo->process($request, $this->getRequestHandler());
         $this->assertSame(403, $response->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

I've renamed method because `with` is sign of cloning object