### PR TITLE
Fix getting tree with unnamed route in group

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -130,14 +130,14 @@ final class RouteCollection implements RouteCollectionInterface
                 continue;
             }
 
-            if (empty($tree[$group->getPrefix()])) {
-                $tree[] = $item->getName();
-            } else {
-                $tree[$group->getPrefix()][] = $item->getName();
-            }
-
             /** @var Route $modifiedItem */
             $modifiedItem = $item->pattern($prefix . $item->getPattern());
+
+            if (empty($tree[$group->getPrefix()])) {
+                $tree[] = $modifiedItem->getName();
+            } else {
+                $tree[$group->getPrefix()][] = $modifiedItem->getName();
+            }
 
             $routeName = $modifiedItem->getName();
             if (isset($this->routes[$routeName])) {


### PR DESCRIPTION
To reproduce install yiisoft/app, add a group to routes:

```php
Group::create('/api', [
    Route::get('/test', [SiteController::class, 'index']),
]),
```

Then check logs or comment `$emitter->emit($response, $request->getMethod() === Method::HEAD);` in index.php to see the error in browser (not displaying it is OK, the error happens after response is made during collecting debug data).

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
