### PR TITLE
Fix clonning bug

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -47,8 +47,11 @@ final class Dispatcher implements DispatcherInterface
 
     public function withMiddlewares(array $middlewares): DispatcherInterface
     {
+        $stack = $this->stack;
+        $this->stack = null;
         $clone = clone $this;
         $clone->middlewares = $middlewares;
+        $this->stack = $stack;
 
         return $clone;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #66 


Disadvantage: the stack will be rebuilt every request when we'are using a request loop. 