### PR TITLE
Remove getRouteCollection method from UrlMatcher

### DIFF
--- a/src/UrlMatcherInterface.php
+++ b/src/UrlMatcherInterface.php
@@ -25,10 +25,4 @@ interface UrlMatcherInterface
      * @return ServerRequestInterface|null current route
      */
     public function getLastMatchedRequest(): ?ServerRequestInterface;
-
-    /**
-     * Returns UrlMatcher current route collection
-     * @return RouteCollectionInterface collection of routes
-     */
-    public function getRouteCollection(): RouteCollectionInterface;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

Merge before https://github.com/yiisoft/router-fastroute/pull/43