### PR TITLE
Fix #141 #148 Add variadic arguments support

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -122,17 +122,20 @@ final class Group
      * Appends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed first.
      *
-     * @param array|callable|string $middlewareDefinition
+     * @param array|callable|string ...$middlewareDefinition
      *
      * @return self
      */
-    public function middleware($middlewareDefinition): self
+    public function middleware(...$middlewareDefinition): self
     {
         if ($this->routesAdded) {
             throw new RuntimeException('middleware() can not be used after routes().');
         }
         $new = clone $this;
-        array_unshift($new->middlewareDefinitions, $middlewareDefinition);
+        array_unshift(
+            $new->middlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         return $new;
     }
 
@@ -140,14 +143,17 @@ final class Group
      * Prepends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed last.
      *
-     * @param array|callable|string $middlewareDefinition
+     * @param array|callable|string ...$middlewareDefinition
      *
      * @return self
      */
-    public function prependMiddleware($middlewareDefinition): self
+    public function prependMiddleware(...$middlewareDefinition): self
     {
         $new = clone $this;
-        $new->middlewareDefinitions[] = $middlewareDefinition;
+        array_push(
+            $new->middlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         $new->middlewareAdded = true;
         return $new;
     }
@@ -171,14 +177,17 @@ final class Group
      * It is useful to avoid invoking one of the parent group middleware for
      * a certain route.
      *
-     * @param mixed $middlewareDefinition
+     * @param mixed ...$middlewareDefinition
      *
      * @return self
      */
-    public function disableMiddleware($middlewareDefinition): self
+    public function disableMiddleware(...$middlewareDefinition): self
     {
         $new = clone $this;
-        $new->disabledMiddlewareDefinitions[] = $middlewareDefinition;
+        array_push(
+            $new->disabledMiddlewareDefinitions,
+            ...array_values($middlewareDefinition),
+        );
         return $new;
     }
 
@@ -195,7 +204,7 @@ final class Group
      *   T is ('prefix'|'namePrefix'|'host') ? string|null :
      *   (T is 'items' ? Group[]|Route[] :
      *     (T is ('hasCorsMiddleware'|'hasDispatcher') ? bool :
-     *       (T is 'middlewareDefinitions' ? array<array-key,array|callable|string> :
+     *       (T is 'middlewareDefinitions' ? list<array|callable|string> :
      *         (T is 'corsMiddleware' ? array|callable|string|null : mixed)
      *       )
      *     )
@@ -235,6 +244,6 @@ final class Group
             }
         }
 
-        return $this->middlewareDefinitions;
+        return array_values($this->middlewareDefinitions);
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -217,17 +217,20 @@ final class Route
      * Appends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed first.
      *
-     * @param array|callable|string $middlewareDefinition
+     * @param array|callable|string ...$middlewareDefinition
      *
      * @return self
      */
-    public function middleware($middlewareDefinition): self
+    public function middleware(...$middlewareDefinition): self
     {
         if ($this->actionAdded) {
             throw new RuntimeException('middleware() can not be used after action().');
         }
         $route = clone $this;
-        $route->middlewareDefinitions[] = $middlewareDefinition;
+        array_push(
+            $route->middlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         return $route;
     }
 
@@ -235,17 +238,20 @@ final class Route
      * Prepends a handler middleware definition that should be invoked for a matched route.
      * Last added handler will be executed first.
      *
-     * @param array|callable|string $middlewareDefinition
+     * @param array|callable|string ...$middlewareDefinition
      *
      * @return self
      */
-    public function prependMiddleware($middlewareDefinition): self
+    public function prependMiddleware(...$middlewareDefinition): self
     {
         if (!$this->actionAdded) {
             throw new RuntimeException('prependMiddleware() can not be used before action().');
         }
         $route = clone $this;
-        array_unshift($route->middlewareDefinitions, $middlewareDefinition);
+        array_unshift(
+            $route->middlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         return $route;
     }
 
@@ -269,14 +275,17 @@ final class Route
      * It is useful to avoid invoking one of the parent group middleware for
      * a certain route.
      *
-     * @param mixed $middlewareDefinition
+     * @param mixed ...$middlewareDefinition
      *
      * @return self
      */
-    public function disableMiddleware($middlewareDefinition): self
+    public function disableMiddleware(...$middlewareDefinition): self
     {
         $route = clone $this;
-        $route->disabledMiddlewareDefinitions[] = $middlewareDefinition;
+        array_push(
+            $route->disabledMiddlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         return $route;
     }
 

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -16,27 +16,39 @@ final class RouteCollector implements RouteCollectorInterface
      */
     private array $middlewareDefinitions = [];
 
-    public function addRoute(Route $route): RouteCollectorInterface
+    public function addRoute(Route ...$route): RouteCollectorInterface
     {
-        $this->items[] = $route;
+        array_push(
+            $this->items,
+            ...array_values($route)
+        );
         return $this;
     }
 
-    public function addGroup(Group $group): RouteCollectorInterface
+    public function addGroup(Group ...$group): RouteCollectorInterface
     {
-        $this->items[] = $group;
+        array_push(
+            $this->items,
+            ...array_values($group),
+        );
         return $this;
     }
 
-    public function middleware($middlewareDefinition): RouteCollectorInterface
+    public function middleware(...$middlewareDefinition): RouteCollectorInterface
     {
-        array_unshift($this->middlewareDefinitions, $middlewareDefinition);
+        array_push(
+            $this->middlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         return $this;
     }
 
-    public function prependMiddleware($middlewareDefinition): RouteCollectorInterface
+    public function prependMiddleware(...$middlewareDefinition): RouteCollectorInterface
     {
-        $this->middlewareDefinitions[] = $middlewareDefinition;
+        array_unshift(
+            $this->middlewareDefinitions,
+            ...array_values($middlewareDefinition)
+        );
         return $this;
     }
 

--- a/src/RouteCollectorInterface.php
+++ b/src/RouteCollectorInterface.php
@@ -9,11 +9,11 @@ interface RouteCollectorInterface
     /**
      * Add a route
      *
-     * @param Route $route
+     * @param Route ...$route
      *
      * @return self
      */
-    public function addRoute(Route $route): self;
+    public function addRoute(Route ...$route): self;
 
     /**
      * Add a group of routes
@@ -28,31 +28,31 @@ interface RouteCollectorInterface
      * $routeCollector->addGroup($group);
      * ```
      *
-     * @param Group $group a group to add
+     * @param Group ...$group a group to add
      *
      * @return self
      */
-    public function addGroup(Group $group): self;
+    public function addGroup(Group ...$group): self;
 
     /**
      * Appends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed first.
      *
-     * @param array|callable|string $middlewareDefinition
+     * @param array|callable|string ...$middlewareDefinition
      *
      * @return self
      */
-    public function middleware($middlewareDefinition): self;
+    public function middleware(...$middlewareDefinition): self;
 
     /**
      * Prepends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed last.
      *
-     * @param array|callable|string $middlewareDefinition
+     * @param array|callable|string ...$middlewareDefinition
      *
      * @return self
      */
-    public function prependMiddleware($middlewareDefinition): self;
+    public function prependMiddleware(...$middlewareDefinition): self;
 
     /**
      * @return Group[]|Route[]

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -23,6 +23,7 @@ use Yiisoft\Router\RouteCollector;
 use Yiisoft\Router\Tests\Support\Container;
 use Yiisoft\Router\Tests\Support\TestMiddleware1;
 use Yiisoft\Router\Tests\Support\TestMiddleware2;
+use Yiisoft\Router\Tests\Support\TestMiddleware3;
 
 final class GroupTest extends TestCase
 {
@@ -48,9 +49,9 @@ final class GroupTest extends TestCase
     public function testDisabledMiddlewareDefinitions(): void
     {
         $group = Group::create()
-            ->middleware(TestMiddleware1::class)
-            ->middleware(TestMiddleware2::class)
-            ->disableMiddleware(TestMiddleware1::class);
+            ->middleware(TestMiddleware3::class)
+            ->prependMiddleware(TestMiddleware1::class, TestMiddleware2::class)
+            ->disableMiddleware(TestMiddleware1::class, TestMiddleware3::class);
 
         $this->assertCount(1, $group->getData('middlewareDefinitions'));
         $this->assertSame(TestMiddleware2::class, $group->getData('middlewareDefinitions')[0]);

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -20,7 +20,6 @@ use Yiisoft\Router\Route;
 use Yiisoft\Router\RouteCollection;
 use Yiisoft\Router\RouteCollector;
 use Yiisoft\Router\RouteNotFoundException;
-use Yiisoft\Router\Tests\Support\Container;
 use Yiisoft\Router\Tests\Support\TestController;
 use Yiisoft\Router\Tests\Support\TestMiddleware1;
 use Yiisoft\Router\Tests\Support\TestMiddleware2;

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -12,6 +12,7 @@ use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 use Yiisoft\Middleware\Dispatcher\MiddlewareDispatcher;
 use Yiisoft\Middleware\Dispatcher\MiddlewareFactory;
 use Yiisoft\Router\Group;
@@ -19,6 +20,12 @@ use Yiisoft\Router\Route;
 use Yiisoft\Router\RouteCollection;
 use Yiisoft\Router\RouteCollector;
 use Yiisoft\Router\RouteNotFoundException;
+use Yiisoft\Router\Tests\Support\Container;
+use Yiisoft\Router\Tests\Support\TestController;
+use Yiisoft\Router\Tests\Support\TestMiddleware1;
+use Yiisoft\Router\Tests\Support\TestMiddleware2;
+use Yiisoft\Router\Tests\Support\TestMiddleware3;
+use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class RouteCollectionTest extends TestCase
 {
@@ -253,6 +260,69 @@ final class RouteCollectionTest extends TestCase
         $this->assertEquals('middleware1', $response2->getReasonPhrase());
     }
 
+    public function testMiddlewaresOrder(): void
+    {
+        $request = new ServerRequest('GET', '/');
+
+        $injectDispatcher = $this->getDispatcher(
+            new SimpleContainer([
+                TestMiddleware1::class => new TestMiddleware1(),
+                TestMiddleware2::class => new TestMiddleware2(),
+                TestMiddleware3::class => new TestMiddleware3(),
+                TestController::class => new TestController(),
+            ])
+        );
+
+        $collector = new RouteCollector();
+
+        $collector
+            ->middleware(TestMiddleware2::class)
+            ->prependMiddleware(TestMiddleware1::class);
+
+        $collector->addRoute(
+            Route::get('/')
+                ->middleware(TestMiddleware3::class)
+                ->action([TestController::class, 'index'])
+                ->name('main')
+        );
+
+        $route = (new RouteCollection($collector))->getRoute('main');
+        $route->injectDispatcher($injectDispatcher);
+
+        $dispatcher = $route->getData('dispatcherWithMiddlewares');
+
+        $response = $dispatcher->dispatch($request, $this->getRequestHandler());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('123', (string) $response->getBody());
+    }
+
+    public function testStaticRouteWithCollectorMiddlewares(): void
+    {
+        $request = new ServerRequest('GET', '/');
+
+        $injectDispatcher = $this->getDispatcher(
+            new SimpleContainer([
+                TestMiddleware1::class => new TestMiddleware1(),
+            ])
+        );
+
+        $collector = new RouteCollector();
+        $collector->middleware(TestMiddleware1::class);
+
+        $collector->addRoute(
+            Route::get('i/{image}')->name('image')
+        );
+
+        $route = (new RouteCollection($collector))->getRoute('image');
+        $route->injectDispatcher($injectDispatcher);
+
+        $dispatcher = $route->getData('dispatcherWithMiddlewares');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Stack is empty.');
+        $dispatcher->dispatch($request, $this->getRequestHandler());
+    }
+
     private function getRequestHandler(): RequestHandlerInterface
     {
         return new class () implements RequestHandlerInterface {
@@ -263,10 +333,10 @@ final class RouteCollectionTest extends TestCase
         };
     }
 
-    private function getDispatcher(): MiddlewareDispatcher
+    private function getDispatcher(ContainerInterface $container = null): MiddlewareDispatcher
     {
         return new MiddlewareDispatcher(
-            new MiddlewareFactory($this->createMock(ContainerInterface::class)),
+            new MiddlewareFactory($container ?? $this->createMock(ContainerInterface::class)),
             $this->createMock(EventDispatcherInterface::class)
         );
     }

--- a/tests/RouteCollectorTest.php
+++ b/tests/RouteCollectorTest.php
@@ -65,11 +65,11 @@ final class RouteCollectorTest extends TestCase
     {
         $collector = new RouteCollector();
 
-        $middleware1 = static fn() => new Response();
-        $middleware2 = static fn() => new Response();
-        $middleware3 = static fn() => new Response();
-        $middleware4 = static fn() => new Response();
-        $middleware5 = static fn() => new Response();
+        $middleware1 = static fn () => new Response();
+        $middleware2 = static fn () => new Response();
+        $middleware3 = static fn () => new Response();
+        $middleware4 = static fn () => new Response();
+        $middleware5 = static fn () => new Response();
 
         $collector
             ->middleware($middleware3, $middleware4)

--- a/tests/RouteCollectorTest.php
+++ b/tests/RouteCollectorTest.php
@@ -16,14 +16,16 @@ final class RouteCollectorTest extends TestCase
     {
         $listRoute = Route::get('/');
         $viewRoute = Route::get('/{id}');
+        $topRoute = Route::get('/top');
 
         $collector = new RouteCollector();
-        $collector->addRoute($listRoute);
-        $collector->addRoute($viewRoute);
+        $collector->addRoute($listRoute, $viewRoute);
+        $collector->addRoute($topRoute);
 
-        $this->assertCount(2, $collector->getItems());
+        $this->assertCount(3, $collector->getItems());
         $this->assertSame($listRoute, $collector->getItems()[0]);
         $this->assertSame($viewRoute, $collector->getItems()[1]);
+        $this->assertSame($topRoute, $collector->getItems()[2]);
     }
 
     public function testAddGroup(): void
@@ -46,11 +48,16 @@ final class RouteCollectorTest extends TestCase
                     ),
             );
 
-        $collector = new RouteCollector();
-        $collector->addGroup($rootGroup);
-        $collector->addGroup($postGroup);
+        $testGroup = Group::create()
+            ->routes(
+                Route::get('test/')
+            );
 
-        $this->assertCount(2, $collector->getItems());
+        $collector = new RouteCollector();
+        $collector->addGroup($rootGroup, $postGroup);
+        $collector->addGroup($testGroup);
+
+        $this->assertCount(3, $collector->getItems());
         $this->assertContainsOnlyInstancesOf(Group::class, $collector->getItems());
     }
 
@@ -58,23 +65,21 @@ final class RouteCollectorTest extends TestCase
     {
         $collector = new RouteCollector();
 
-        $middleware1 = static function () {
-            return new Response();
-        };
-        $middleware2 = static function () {
-            return new Response();
-        };
-        $middleware3 = static function () {
-            return new Response();
-        };
+        $middleware1 = static fn() => new Response();
+        $middleware2 = static fn() => new Response();
+        $middleware3 = static fn() => new Response();
+        $middleware4 = static fn() => new Response();
+        $middleware5 = static fn() => new Response();
 
         $collector
-            ->prependMiddleware($middleware3)
-            ->middleware($middleware2)
-            ->middleware($middleware1);
-        $this->assertCount(3, $collector->getMiddlewareDefinitions());
+            ->middleware($middleware3, $middleware4)
+            ->middleware($middleware5)
+            ->prependMiddleware($middleware1, $middleware2);
+        $this->assertCount(5, $collector->getMiddlewareDefinitions());
         $this->assertSame($middleware1, $collector->getMiddlewareDefinitions()[0]);
         $this->assertSame($middleware2, $collector->getMiddlewareDefinitions()[1]);
         $this->assertSame($middleware3, $collector->getMiddlewareDefinitions()[2]);
+        $this->assertSame($middleware4, $collector->getMiddlewareDefinitions()[3]);
+        $this->assertSame($middleware5, $collector->getMiddlewareDefinitions()[4]);
     }
 }

--- a/tests/Support/TestMiddleware3.php
+++ b/tests/Support/TestMiddleware3.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Router\Tests\Support;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class TestMiddleware3 implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle(
+            $request->withAttribute(
+                'content',
+                $request->getAttribute('content', '') . '3'
+            )
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #141 #148 

- `Route::middleware()`
- `Route::prependMiddleware()`
- `Route::disableMiddleware()`
- `Group::middleware()`
- `Group::prependMiddleware()`
- `Group::disableMiddleware()`
- `RouteCollector::addRoute()`
- `RouteCollector::addGroup()`
- `RouteCollector::middleware()`
- `RouteCollector::prependMiddleware()`

And:
• swaped implementations of methods `RouteCollector::middleware()` and `RouteCollector::prependMiddleware()`;
• don't add middlewares from collector to static routes.