### PR TITLE
Fix middlewares order in group

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -132,7 +132,7 @@ final class Group
             throw new RuntimeException('middleware() can not be used after routes().');
         }
         $new = clone $this;
-        array_unshift(
+        array_push(
             $new->middlewareDefinitions,
             ...array_values($middlewareDefinition)
         );
@@ -150,7 +150,7 @@ final class Group
     public function prependMiddleware(...$middlewareDefinition): self
     {
         $new = clone $this;
-        array_push(
+        array_unshift(
             $new->middlewareDefinitions,
             ...array_values($middlewareDefinition)
         );

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -114,9 +114,7 @@ final class RouteCollection implements RouteCollectionInterface
         $host = null;
         foreach ($items as $item) {
             if (!$this->isStaticRoute($item)) {
-                foreach ($group->getData('middlewareDefinitions') as $middleware) {
-                    $item = $item->prependMiddleware($middleware);
-                }
+                $item = $item->prependMiddleware(...$group->getData('middlewareDefinitions'));
             }
 
             if ($group->getData('host') !== null && $item->getData('host') === null) {

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -31,16 +31,12 @@ final class GroupTest extends TestCase
     {
         $group = Group::create();
 
-        $middleware1 = static function () {
-            return new Response();
-        };
-        $middleware2 = static function () {
-            return new Response();
-        };
+        $middleware1 = static fn () => new Response();
+        $middleware2 = static fn () => new Response();
 
         $group = $group
-            ->middleware($middleware2)
-            ->middleware($middleware1);
+            ->middleware($middleware1)
+            ->middleware($middleware2);
         $this->assertCount(2, $group->getData('middlewareDefinitions'));
         $this->assertSame($middleware1, $group->getData('middlewareDefinitions')[0]);
         $this->assertSame($middleware2, $group->getData('middlewareDefinitions')[1]);
@@ -192,18 +188,14 @@ final class GroupTest extends TestCase
         $listRoute = Route::get('/');
         $viewRoute = Route::get('/{id}');
 
-        $middleware1 = static function () {
-            return new Response();
-        };
-        $middleware2 = static function () {
-            return new Response();
-        };
+        $middleware1 = static fn () => new Response();
+        $middleware2 = static fn () => new Response();
 
         $root = Group::create()
             ->routes(
                 Group::create('/api')
-                    ->middleware($middleware2)
                     ->middleware($middleware1)
+                    ->middleware($middleware2)
                     ->routes(
                         $logoutRoute,
                         Group::create('/post')
@@ -215,6 +207,7 @@ final class GroupTest extends TestCase
             );
 
         $this->assertCount(1, $root->getData('items'));
+
         /** @var Group $api */
         $api = $root->getData('items')[0];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Changed middlewares order in groups. Now same order in `Route`, `Group` and `RouteCollector`.