### PR TITLE
Replace two `RouteCollectorInterface` methods `addRoute()` and `addGroup()` to single `addItem()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Yii Router Change Log
 
-## 3.0.1 under development
+## 4.0.0 under development
 
-- no changes in this release.
+- Chg #207: Replace two `RouteCollectorInterface` methods `addRoute()` and `addGroup()` to single `addItem()` (@vjik)
 
 ## 3.0.0 February 17, 2023
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $routes = [
 
 // Add routes defined to route collector
 $collector = $container->get(RouteCollectorInterface::class);
-$collector->addGroup(Group::create(null)->routes($routes));
+$collector->addItem(Group::create(null)->routes($routes));
 
 // Initialize URL matcher
 /** @var UrlMatcherInterface $urlMatcher */
@@ -213,7 +213,7 @@ use \Yiisoft\Router\RouteCollectorInterface;
 // for obtaining router see adapter package of choice readme
 $collector = $container->get(RouteCollectorInterface::class);
     
-$collector->addGroup(
+$collector->addItem(
     Group::create('/api')
         ->middleware(ApiAuthentication::class)
         ->host('https://example.com')
@@ -284,7 +284,7 @@ $request = $container
 $responseFactory = $container->get(ResponseFactoryInterface::class);
 $notFoundHandler = new NotFoundHandler($responseFactory);
 $collector = $container->get(RouteCollectorInterface::class);
-$collector->addRoute(
+$collector->addItem(
     Route::get('/test/{id:\w+}')
         ->action(static function (CurrentRoute $currentRoute, RequestHandlerInterface $next) use ($responseFactory) {
             $id = $currentRoute->getArgument('id');

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -16,20 +16,11 @@ final class RouteCollector implements RouteCollectorInterface
      */
     private array $middlewareDefinitions = [];
 
-    public function addRoute(Route ...$route): RouteCollectorInterface
+    public function addItem(Route|Group ...$item): RouteCollectorInterface
     {
         array_push(
             $this->items,
-            ...array_values($route)
-        );
-        return $this;
-    }
-
-    public function addGroup(Group ...$group): RouteCollectorInterface
-    {
-        array_push(
-            $this->items,
-            ...array_values($group),
+            ...array_values($item)
         );
         return $this;
     }

--- a/src/RouteCollectorInterface.php
+++ b/src/RouteCollectorInterface.php
@@ -7,26 +7,9 @@ namespace Yiisoft\Router;
 interface RouteCollectorInterface
 {
     /**
-     * Add a route.
+     * Add a route or a group of routes.
      */
-    public function addRoute(Route ...$route): self;
-
-    /**
-     * Add a group of routes.
-     *
-     * ```php
-     * $group = Group::create('/api')
-     * ->middleware($myMiddleware)
-     * ->routes(
-     *     Route::get('/users', function () {}),
-     *     Route::get('/contacts', function () {}),
-     * );
-     * $routeCollector->addGroup($group);
-     * ```
-     *
-     * @param Group ...$group A group to add.
-     */
-    public function addGroup(Group ...$group): self;
+    public function addItem(Route|Group ...$item): self;
 
     /**
      * Appends a handler middleware definition that should be invoked for a matched route.

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -107,7 +107,7 @@ final class GroupTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('request1');
@@ -142,7 +142,7 @@ final class GroupTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('request1');
@@ -171,7 +171,7 @@ final class GroupTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('request1');
@@ -319,7 +319,7 @@ final class GroupTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
         $routeCollection = new RouteCollection($collector);
 
         $this->assertCount(3, $routeCollection->getRoutes());
@@ -344,7 +344,7 @@ final class GroupTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
         $routeCollection = new RouteCollection($collector);
 
         $this->assertCount(5, $routeCollection->getRoutes());
@@ -369,7 +369,7 @@ final class GroupTest extends TestCase
         );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $this->assertCount(7, $routeCollection->getRoutes());
@@ -393,7 +393,7 @@ final class GroupTest extends TestCase
             static fn () => new Response(204)
         );
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $this->assertCount(8, $routeCollection->getRoutes());

--- a/tests/Middleware/RouterTest.php
+++ b/tests/Middleware/RouterTest.php
@@ -81,7 +81,7 @@ final class RouterTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
         $routeCollection = new RouteCollection($collector);
 
         $request = new ServerRequest('OPTIONS', '/post');
@@ -164,7 +164,7 @@ final class RouterTest extends TestCase
         $response = $this->processWithRouter(
             request: new ServerRequest('GET', '/'),
             routes: new RouteCollection(
-                (new RouteCollector())->addRoute(
+                (new RouteCollector())->addItem(
                     Route::get('/')
                         ->middleware($middleware)
                         ->action(static fn () => new Response(200))

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -36,7 +36,7 @@ final class RouteCollectionTest extends TestCase
         $group = Group::create()->routes($listRoute, $viewRoute);
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("A route with name 'my-route' already exists.");
@@ -52,8 +52,7 @@ final class RouteCollectionTest extends TestCase
         $group = Group::create()->routes($listRoute);
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
-        $collector->addRoute($viewRoute);
+        $collector->addItem($group, $viewRoute);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("A route with name 'my-route' already exists.");
@@ -68,7 +67,7 @@ final class RouteCollectionTest extends TestCase
         $group = Group::create()->routes($listRoute);
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $this->expectException(RouteNotFoundException::class);
         $this->expectExceptionMessage('Cannot generate URI for route "wrong-name"; route not found');
@@ -86,7 +85,7 @@ final class RouteCollectionTest extends TestCase
         $group = Group::create()->routes($listRoute, $viewRoute);
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('my-route');
@@ -105,7 +104,7 @@ final class RouteCollectionTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('image');
@@ -142,8 +141,7 @@ final class RouteCollectionTest extends TestCase
             ->namePrefix('/api');
 
         $collector = new RouteCollector();
-        $collector->addGroup($group1);
-        $collector->addGroup($group2);
+        $collector->addItem($group1, $group2);
 
         $routeCollection = new RouteCollection($collector);
         $routeTree = $routeCollection->getRouteTree();
@@ -177,7 +175,7 @@ final class RouteCollectionTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $routes = $routeCollection->getRoutes();
@@ -203,7 +201,7 @@ final class RouteCollectionTest extends TestCase
             ->host('https://yiiframework.com/');
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route1 = $routeCollection->getRoute('image');
@@ -234,7 +232,7 @@ final class RouteCollectionTest extends TestCase
             )->namePrefix('api');
 
         $collector = new RouteCollector();
-        $collector->addGroup($group);
+        $collector->addItem($group);
 
         $routeCollection = new RouteCollection($collector);
         $route1 = $routeCollection->getRoute('api/post/view');
@@ -272,8 +270,7 @@ final class RouteCollectionTest extends TestCase
 
         $collector = new RouteCollector();
         $collector->middleware($middleware);
-        $collector->addGroup($group);
-        $collector->addRoute($viewRoute);
+        $collector->addItem($group, $viewRoute);
 
         $routeCollection = new RouteCollection($collector);
         $route1 = $routeCollection->getRoute('list');
@@ -325,13 +322,9 @@ final class RouteCollectionTest extends TestCase
             ->action([TestController::class, 'index'])
             ->name('main');
 
-        if ($groupWrapped) {
-            $collector->addGroup(
-                Group::create()->routes($rawRoute)
-            );
-        } else {
-            $collector->addRoute($rawRoute);
-        }
+        $collector->addItem(
+            $groupWrapped ? Group::create()->routes($rawRoute) : $rawRoute
+        );
 
         $route = (new RouteCollection($collector))->getRoute('main');
         $route->injectDispatcher($injectDispatcher);
@@ -356,7 +349,7 @@ final class RouteCollectionTest extends TestCase
         $collector = new RouteCollector();
         $collector->middleware(TestMiddleware1::class);
 
-        $collector->addRoute(
+        $collector->addItem(
             Route::get('i/{image}')->name('image')
         );
 

--- a/tests/RouteCollectorTest.php
+++ b/tests/RouteCollectorTest.php
@@ -19,8 +19,7 @@ final class RouteCollectorTest extends TestCase
         $topRoute = Route::get('/top');
 
         $collector = new RouteCollector();
-        $collector->addRoute($listRoute, $viewRoute);
-        $collector->addRoute(top: $topRoute);
+        $collector->addItem($listRoute, $viewRoute, top: $topRoute);
 
         $this->assertCount(3, $collector->getItems());
         $this->assertSame($listRoute, $collector->getItems()[0]);
@@ -54,8 +53,7 @@ final class RouteCollectorTest extends TestCase
             );
 
         $collector = new RouteCollector();
-        $collector->addGroup($rootGroup, $postGroup);
-        $collector->addGroup(test: $testGroup);
+        $collector->addItem($rootGroup, $postGroup, test: $testGroup);
 
         $this->assertCount(3, $collector->getItems());
         $this->assertContainsOnlyInstancesOf(Group::class, $collector->getItems());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
