### PR TITLE
Make `Route`, `Group` and `MatchingResult` dispatcher independent

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -14,8 +14,10 @@ name: rector
 jobs:
   rector:
     uses: yiisoft/actions/.github/workflows/rector.yml@master
+    secrets:
+      token: ${{ secrets.YIISOFT_GITHUB_TOKEN }}
     with:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.0']
+        ['8.2']

--- a/.phpstorm.meta.php/Group.php
+++ b/.phpstorm.meta.php/Group.php
@@ -11,9 +11,8 @@ namespace PHPSTORM_META {
         'host',
         'hosts',
         'corsMiddleware',
-        'items',
-        'middlewareDefinitions',
-        'hasDispatcher',
-        'hasCorsMiddleware'
+        'routes',
+        'hasCorsMiddleware',
+        'enabledMiddlewares',
     );
 }

--- a/.phpstorm.meta.php/Route.php
+++ b/.phpstorm.meta.php/Route.php
@@ -7,14 +7,13 @@ namespace PHPSTORM_META {
     registerArgumentsSet(
         'routeDataKeys',
         'name',
+        'pattern',
         'host',
         'hosts',
-        'pattern',
         'methods',
-        'override',
         'defaults',
-        'dispatcherWithMiddlewares',
-        'hasDispatcher',
-        'hasMiddlewares'
+        'override',
+        'hasMiddlewares',
+        'enabledMiddlewares',
     );
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New #195: Add debug collector for `yiisoft/yii-debug` (@xepozz)
 - Chg #207: Replace two `RouteCollectorInterface` methods `addRoute()` and `addGroup()` to single `addRoute()` (@vjik)
 - Enh #202: Add support for `psr/http-message` version `^2.0` (@vjik)
-- Chg #222: Make `Route`, `Group` and `MatchingResult` dispatcher independent (@rustamwin, @vjik)
+- Chg #222: Make `Route`, `Group` and `MatchingResult` dispatcher-independent (@rustamwin, @vjik)
 
 ## 3.0.0 February 17, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New #195: Add debug collector for `yiisoft/yii-debug` (@xepozz)
 - Chg #207: Replace two `RouteCollectorInterface` methods `addRoute()` and `addGroup()` to single `addRoute()` (@vjik)
 - Enh #202: Add support for `psr/http-message` version `^2.0` (@vjik)
+- Chg #222: Make `Route`, `Group` and `MatchingResult` dispatcher independent (@rustamwin, @vjik)
 
 ## 3.0.0 February 17, 2023
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,7 +5,7 @@ These notes highlight changes that could break your application when you upgrade
 
 ## 4.0.0
 
-In this release classes `Route`, `Group` and `MatchingResult` are made dispatcher independent. Now you don't can inject
+In this release classes `Route`, `Group` and `MatchingResult` are made dispatcher-independent. Now you don't can inject
 own middleware dispatcher to group or to route.
 
 The following backward incompatible changes have been made.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,34 @@
+# Upgrading Instructions for Yii Router
+
+This file contains the upgrade notes for the Yii Router.
+These notes highlight changes that could break your application when you upgrade it from one major version to another.
+
+## 4.0.0
+
+In this release classes `Route`, `Group` and `MatchingResult` are made dispatcher independent. Now you don't can inject
+own middleware dispatcher to group or to route.
+
+The following backward incompatible changes have been made.
+
+### `Route`
+
+- Removed parameter `$dispatcher` from `Route` creating methods: `get()`, `post()`, `put()`, `delete()`, `patch()`,
+  `head()`, `options()`, `methods()`.
+- Removed methods `Route::injectDispatcher()` and `Route::withDispatcher()`.
+- `Route::getData()` changes:
+  - removed elements `dispatcherWithMiddlewares` and `hasDispatcher`;
+  - added element `enabledMiddlewares`.
+ 
+### `Group`
+
+- Removed parameter `$dispatcher` from `Group::create()` method.
+- Removed method `Group::withDispatcher()`.
+- `Group::getData()` changes:
+  - removed element `hasDispatcher`;
+  - key `items` renamed to `routes`;
+  - key `middlewareDefinitions` renamed to `enabledMiddlewares`.
+
+### `MatchingResult`
+
+- Removed `MatchingResult` implementation from `MiddlewareInterface`, so it is no longer middleware.
+- Removed method `MatchingResult::process()`.

--- a/src/Debug/DebugRoutesCommand.php
+++ b/src/Debug/DebugRoutesCommand.php
@@ -14,6 +14,9 @@ use Yiisoft\Router\RouteCollectionInterface;
 use Yiisoft\VarDumper\VarDumper;
 use Yiisoft\Yii\Debug\Debugger;
 
+/**
+ * @codeCoverageIgnore
+ */
 final class DebugRoutesCommand extends Command
 {
     public const COMMAND_NAME = 'debug:routes';

--- a/src/Debug/RouterCollector.php
+++ b/src/Debug/RouterCollector.php
@@ -12,6 +12,9 @@ use Yiisoft\Router\RouteCollectionInterface;
 use Yiisoft\Yii\Debug\Collector\CollectorTrait;
 use Yiisoft\Yii\Debug\Collector\SummaryCollectorInterface;
 
+/**
+ * @codeCoverageIgnore
+ */
 final class RouterCollector implements SummaryCollectorInterface
 {
     use CollectorTrait;

--- a/src/Debug/UrlMatcherInterfaceProxy.php
+++ b/src/Debug/UrlMatcherInterfaceProxy.php
@@ -8,6 +8,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Yiisoft\Router\MatchingResult;
 use Yiisoft\Router\UrlMatcherInterface;
 
+/**
+ * @codeCoverageIgnore
+ */
 final class UrlMatcherInterfaceProxy implements UrlMatcherInterface
 {
     public function __construct(private UrlMatcherInterface $urlMatcher, private RouterCollector $routerCollector)

--- a/src/Group.php
+++ b/src/Group.php
@@ -45,7 +45,8 @@ final class Group
      *
      * @param string|null $prefix URL prefix to prepend to all routes of the group.
      */
-    public static function create(?string $prefix = null): self {
+    public static function create(?string $prefix = null): self
+    {
         return new self($prefix);
     }
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Router;
 
 use InvalidArgumentException;
 use RuntimeException;
-use Yiisoft\Middleware\Dispatcher\MiddlewareDispatcher;
 
 use function in_array;
 
@@ -15,12 +14,12 @@ final class Group
     /**
      * @var Group[]|Route[]
      */
-    private array $items = [];
+    private array $routes = [];
 
     /**
      * @var array[]|callable[]|string[]
      */
-    private array $middlewareDefinitions = [];
+    private array $middlewares = [];
 
     /**
      * @var string[]
@@ -29,28 +28,25 @@ final class Group
     private ?string $namePrefix = null;
     private bool $routesAdded = false;
     private bool $middlewareAdded = false;
-    private array $disabledMiddlewareDefinitions = [];
+    private array $disabledMiddlewares = [];
 
     /**
      * @var array|callable|string|null Middleware definition for CORS requests.
      */
     private $corsMiddleware = null;
 
-    private function __construct(private ?string $prefix = null, private ?MiddlewareDispatcher $dispatcher = null)
-    {
+    private function __construct(
+        private ?string $prefix = null
+    ) {
     }
 
     /**
      * Create a new group instance.
      *
      * @param string|null $prefix URL prefix to prepend to all routes of the group.
-     * @param MiddlewareDispatcher|null $dispatcher Middleware dispatcher to use for the group.
      */
-    public static function create(
-        ?string $prefix = null,
-        MiddlewareDispatcher $dispatcher = null
-    ): self {
-        return new self($prefix, $dispatcher);
+    public static function create(?string $prefix = null): self {
+        return new self($prefix);
     }
 
     public function routes(self|Route ...$routes): self
@@ -58,31 +54,12 @@ final class Group
         if ($this->middlewareAdded) {
             throw new RuntimeException('routes() can not be used after prependMiddleware().');
         }
-        $new = clone $this;
-        foreach ($routes as $route) {
-            if ($new->dispatcher !== null && !$route->getData('hasDispatcher')) {
-                $route = $route->withDispatcher($new->dispatcher);
-            }
-            $new->items[] = $route;
-        }
 
+        $new = clone $this;
+        $new->routes = $routes;
         $new->routesAdded = true;
 
         return $new;
-    }
-
-    public function withDispatcher(MiddlewareDispatcher $dispatcher): self
-    {
-        $group = clone $this;
-        $group->dispatcher = $dispatcher;
-        foreach ($group->items as $index => $item) {
-            if (!$item->getData('hasDispatcher')) {
-                $item = $item->withDispatcher($dispatcher);
-                $group->items[$index] = $item;
-            }
-        }
-
-        return $group;
     }
 
     /**
@@ -103,16 +80,18 @@ final class Group
      * Appends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed first.
      */
-    public function middleware(array|callable|string ...$middlewareDefinition): self
+    public function middleware(array|callable|string ...$definition): self
     {
         if ($this->routesAdded) {
             throw new RuntimeException('middleware() can not be used after routes().');
         }
+
         $new = clone $this;
         array_push(
-            $new->middlewareDefinitions,
-            ...array_values($middlewareDefinition)
+            $new->middlewares,
+            ...array_values($definition)
         );
+
         return $new;
     }
 
@@ -120,12 +99,12 @@ final class Group
      * Prepends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed last.
      */
-    public function prependMiddleware(array|callable|string ...$middlewareDefinition): self
+    public function prependMiddleware(array|callable|string ...$definition): self
     {
         $new = clone $this;
         array_unshift(
-            $new->middlewareDefinitions,
-            ...array_values($middlewareDefinition)
+            $new->middlewares,
+            ...array_values($definition)
         );
         $new->middlewareAdded = true;
         return $new;
@@ -163,12 +142,12 @@ final class Group
      * It is useful to avoid invoking one of the parent group middleware for
      * a certain route.
      */
-    public function disableMiddleware(mixed ...$middlewareDefinition): self
+    public function disableMiddleware(mixed ...$definition): self
     {
         $new = clone $this;
         array_push(
-            $new->disabledMiddlewareDefinitions,
-            ...array_values($middlewareDefinition),
+            $new->disabledMiddlewares,
+            ...array_values($definition),
         );
         return $new;
     }
@@ -180,10 +159,10 @@ final class Group
      *
      * @psalm-return (
      *   T is ('prefix'|'namePrefix'|'host') ? string|null :
-     *   (T is 'items' ? Group[]|Route[] :
+     *   (T is 'routes' ? Group[]|Route[] :
      *     (T is 'hosts' ? array<array-key, string> :
-     *       (T is ('hasCorsMiddleware'|'hasDispatcher') ? bool :
-     *         (T is 'middlewareDefinitions' ? list<array|callable|string> :
+     *       (T is ('hasCorsMiddleware') ? bool :
+     *         (T is 'enabledMiddlewares' ? list<array|callable|string> :
      *           (T is 'corsMiddleware' ? array|callable|string|null : mixed)
      *         )
      *       )
@@ -199,23 +178,21 @@ final class Group
             'host' => $this->hosts[0] ?? null,
             'hosts' => $this->hosts,
             'corsMiddleware' => $this->corsMiddleware,
-            'items' => $this->items,
+            'routes' => $this->routes,
             'hasCorsMiddleware' => $this->corsMiddleware !== null,
-            'hasDispatcher' => $this->dispatcher !== null,
-            'middlewareDefinitions' => $this->getMiddlewareDefinitions(),
+            'enabledMiddlewares' => $this->getEnabledMiddlewares(),
             default => throw new InvalidArgumentException('Unknown data key: ' . $key),
         };
     }
 
-    private function getMiddlewareDefinitions(): array
+    private function getEnabledMiddlewares(): array
     {
-        /** @var mixed $definition */
-        foreach ($this->middlewareDefinitions as $index => $definition) {
-            if (in_array($definition, $this->disabledMiddlewareDefinitions, true)) {
-                unset($this->middlewareDefinitions[$index]);
+        foreach ($this->middlewares as $index => $definition) {
+            if (in_array($definition, $this->disabledMiddlewares, true)) {
+                unset($this->middlewares[$index]);
             }
         }
 
-        return array_values($this->middlewareDefinitions);
+        return array_values($this->middlewares);
     }
 }

--- a/src/Group.php
+++ b/src/Group.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Router;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Yiisoft\Router\Internal\MiddlewareFilter;
 
 use function in_array;
 
@@ -18,6 +19,7 @@ final class Group
 
     /**
      * @var array[]|callable[]|string[]
+     * @psalm-var list<array|callable|string>
      */
     private array $middlewares = [];
 
@@ -209,12 +211,7 @@ final class Group
             return $this->enabledMiddlewaresCache;
         }
 
-        $this->enabledMiddlewaresCache = array_values(
-            array_filter(
-                $this->middlewares,
-                fn ($definition) => !in_array($definition, $this->disabledMiddlewares, true)
-            )
-        );
+        $this->enabledMiddlewaresCache = MiddlewareFilter::filter($this->middlewares, $this->disabledMiddlewares);
 
         return $this->enabledMiddlewaresCache;
     }

--- a/src/Internal/MiddlewareFilter.php
+++ b/src/Internal/MiddlewareFilter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Router\Internal;
+
+/**
+ * @internal
+ */
+final class MiddlewareFilter
+{
+    /**
+     * @param array[]|callable[]|string[] $middlewares
+     * @return array[]|callable[]|string[]
+     *
+     * @psalm-param list<array|callable|string> $middlewares
+     * @psalm-return list<array|callable|string>
+     */
+    public static function filter(array $middlewares, array $disabledMiddlewares): array
+    {
+        $result = [];
+
+        foreach ($middlewares as $middleware) {
+            if (in_array($middleware, $disabledMiddlewares, true)) {
+                continue;
+            }
+
+            $result[] = $middleware;
+        }
+
+        return $result;
+    }
+}

--- a/src/MatchingResult.php
+++ b/src/MatchingResult.php
@@ -4,18 +4,14 @@ declare(strict_types=1);
 
 namespace Yiisoft\Router;
 
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use Yiisoft\Http\Method;
-use Yiisoft\Middleware\Dispatcher\MiddlewareDispatcher;
 
-final class MatchingResult implements MiddlewareInterface
+final class MatchingResult
 {
     /**
-     * @var array<string,string>
+     * @var string[]
+     * @psalm-var array<string,string>
      */
     private array $arguments = [];
 
@@ -24,21 +20,13 @@ final class MatchingResult implements MiddlewareInterface
      */
     private array $methods = [];
 
-    private ?MiddlewareDispatcher $dispatcher = null;
-
     private function __construct(private ?Route $route)
     {
     }
 
-    public function withDispatcher(MiddlewareDispatcher $dispatcher): self
-    {
-        $new = clone $this;
-        $new->dispatcher = $dispatcher;
-        return $new;
-    }
-
     /**
-     * @param array<string,string> $arguments
+     * @param string[] $arguments
+     * @psalm-param array<string,string> $arguments
      */
     public static function fromSuccess(Route $route, array $arguments): self
     {
@@ -71,7 +59,8 @@ final class MatchingResult implements MiddlewareInterface
     }
 
     /**
-     * @return array<string,string>
+     * @return string[]
+     * @psalm-return array<string,string>
      */
     public function arguments(): array
     {
@@ -93,22 +82,5 @@ final class MatchingResult implements MiddlewareInterface
         }
 
         return $this->route;
-    }
-
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
-    {
-        if (!$this->isSuccess()) {
-            return $handler->handle($request);
-        }
-
-        // Inject dispatcher only if we have not previously injected.
-        // This improves performance in event-loop applications.
-        if ($this->dispatcher !== null && !$this->route->getData('hasDispatcher')) {
-            $this->route->injectDispatcher($this->dispatcher);
-        }
-
-        return $this->route
-            ->getData('dispatcherWithMiddlewares')
-            ->dispatch($request, $handler);
     }
 }

--- a/src/Middleware/Router.php
+++ b/src/Middleware/Router.php
@@ -54,8 +54,8 @@ final class Router implements MiddlewareInterface
 
         $this->currentRoute->setRouteWithArguments($result->route(), $result->arguments());
 
-        return $result
-            ->withDispatcher($this->dispatcher)
-            ->process($request, $handler);
+        return $this->dispatcher
+            ->withMiddlewares($result->route()->getData('enabledMiddlewares'))
+            ->dispatch($request, $handler);
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -36,7 +36,7 @@ final class Route implements Stringable
     /**
      * @psalm-var list<array|callable|string>|null
      */
-    private ?array $enabledMiddlewares = null;
+    private ?array $enabledMiddlewaresCache = null;
 
     /**
      * @var array<string,string>
@@ -161,11 +161,15 @@ final class Route implements Stringable
         if ($this->actionAdded) {
             throw new RuntimeException('middleware() can not be used after action().');
         }
+
         $route = clone $this;
         array_push(
             $route->middlewares,
             ...array_values($definition)
         );
+
+        $route->enabledMiddlewaresCache = null;
+
         return $route;
     }
 
@@ -178,11 +182,15 @@ final class Route implements Stringable
         if (!$this->actionAdded) {
             throw new RuntimeException('prependMiddleware() can not be used before action().');
         }
+
         $route = clone $this;
         array_unshift(
             $route->middlewares,
             ...array_values($definition)
         );
+
+        $route->enabledMiddlewaresCache = null;
+
         return $route;
     }
 
@@ -209,6 +217,9 @@ final class Route implements Stringable
             $route->disabledMiddlewares,
             ...array_values($definition)
         );
+
+        $route->enabledMiddlewaresCache = null;
+
         return $route;
     }
 
@@ -294,17 +305,17 @@ final class Route implements Stringable
      */
     private function getEnabledMiddlewares(): array
     {
-        if ($this->enabledMiddlewares !== null) {
-            return $this->enabledMiddlewares;
+        if ($this->enabledMiddlewaresCache !== null) {
+            return $this->enabledMiddlewaresCache;
         }
 
-        $this->enabledMiddlewares = array_values(
+        $this->enabledMiddlewaresCache = array_values(
             array_filter(
                 $this->middlewares,
                 fn ($definition) => !in_array($definition, $this->disabledMiddlewares, true)
             )
         );
 
-        return $this->enabledMiddlewares;
+        return $this->enabledMiddlewaresCache;
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use RuntimeException;
 use Stringable;
 use Yiisoft\Http\Method;
+use Yiisoft\Router\Internal\MiddlewareFilter;
 
 use function in_array;
 
@@ -309,12 +310,7 @@ final class Route implements Stringable
             return $this->enabledMiddlewaresCache;
         }
 
-        $this->enabledMiddlewaresCache = array_values(
-            array_filter(
-                $this->middlewares,
-                fn ($definition) => !in_array($definition, $this->disabledMiddlewares, true)
-            )
-        );
+        $this->enabledMiddlewaresCache = MiddlewareFilter::filter($this->middlewares, $this->disabledMiddlewares);
 
         return $this->enabledMiddlewaresCache;
     }

--- a/src/Route.php
+++ b/src/Route.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 use RuntimeException;
 use Stringable;
 use Yiisoft\Http\Method;
-use Yiisoft\Middleware\Dispatcher\MiddlewareDispatcher;
 
 use function in_array;
 
@@ -28,10 +27,16 @@ final class Route implements Stringable
 
     /**
      * @var array[]|callable[]|string[]
+     * @psalm-var list<array|callable|string>
      */
-    private array $middlewareDefinitions = [];
+    private array $middlewares = [];
 
-    private array $disabledMiddlewareDefinitions = [];
+    private array $disabledMiddlewares = [];
+
+    /**
+     * @psalm-var list<array|callable|string>|null
+     */
+    private ?array $enabledMiddlewares = null;
 
     /**
      * @var array<string,string>
@@ -44,69 +49,50 @@ final class Route implements Stringable
     private function __construct(
         private array $methods,
         private string $pattern,
-        private ?MiddlewareDispatcher $dispatcher = null
     ) {
     }
 
-    /**
-     * @psalm-assert MiddlewareDispatcher $this->dispatcher
-     */
-    public function injectDispatcher(MiddlewareDispatcher $dispatcher): void
+    public static function get(string $pattern): self
     {
-        $this->dispatcher = $dispatcher;
+        return self::methods([Method::GET], $pattern);
     }
 
-    public function withDispatcher(MiddlewareDispatcher $dispatcher): self
+    public static function post(string $pattern): self
     {
-        $route = clone $this;
-        $route->dispatcher = $dispatcher;
-        return $route;
+        return self::methods([Method::POST], $pattern);
     }
 
-    public static function get(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
+    public static function put(string $pattern): self
     {
-        return self::methods([Method::GET], $pattern, $dispatcher);
+        return self::methods([Method::PUT], $pattern);
     }
 
-    public static function post(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
+    public static function delete(string $pattern): self
     {
-        return self::methods([Method::POST], $pattern, $dispatcher);
+        return self::methods([Method::DELETE], $pattern);
     }
 
-    public static function put(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
+    public static function patch(string $pattern): self
     {
-        return self::methods([Method::PUT], $pattern, $dispatcher);
+        return self::methods([Method::PATCH], $pattern);
     }
 
-    public static function delete(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
+    public static function head(string $pattern): self
     {
-        return self::methods([Method::DELETE], $pattern, $dispatcher);
+        return self::methods([Method::HEAD], $pattern);
     }
 
-    public static function patch(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
+    public static function options(string $pattern): self
     {
-        return self::methods([Method::PATCH], $pattern, $dispatcher);
-    }
-
-    public static function head(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
-    {
-        return self::methods([Method::HEAD], $pattern, $dispatcher);
-    }
-
-    public static function options(string $pattern, ?MiddlewareDispatcher $dispatcher = null): self
-    {
-        return self::methods([Method::OPTIONS], $pattern, $dispatcher);
+        return self::methods([Method::OPTIONS], $pattern);
     }
 
     /**
      * @param string[] $methods
      */
-    public static function methods(
-        array $methods,
-        string $pattern,
-        ?MiddlewareDispatcher $dispatcher = null
-    ): self {
-        return new self($methods, $pattern, $dispatcher);
+    public static function methods(array $methods, string $pattern): self
+    {
+        return new self($methods, $pattern);
     }
 
     public function name(string $name): self
@@ -170,15 +156,15 @@ final class Route implements Stringable
      * Appends a handler middleware definition that should be invoked for a matched route.
      * First added handler will be executed first.
      */
-    public function middleware(array|callable|string ...$middlewareDefinition): self
+    public function middleware(array|callable|string ...$definition): self
     {
         if ($this->actionAdded) {
             throw new RuntimeException('middleware() can not be used after action().');
         }
         $route = clone $this;
         array_push(
-            $route->middlewareDefinitions,
-            ...array_values($middlewareDefinition)
+            $route->middlewares,
+            ...array_values($definition)
         );
         return $route;
     }
@@ -187,15 +173,15 @@ final class Route implements Stringable
      * Prepends a handler middleware definition that should be invoked for a matched route.
      * Last added handler will be executed first.
      */
-    public function prependMiddleware(array|callable|string ...$middlewareDefinition): self
+    public function prependMiddleware(array|callable|string ...$definition): self
     {
         if (!$this->actionAdded) {
             throw new RuntimeException('prependMiddleware() can not be used before action().');
         }
         $route = clone $this;
         array_unshift(
-            $route->middlewareDefinitions,
-            ...array_values($middlewareDefinition)
+            $route->middlewares,
+            ...array_values($definition)
         );
         return $route;
     }
@@ -206,7 +192,7 @@ final class Route implements Stringable
     public function action(array|callable|string $middlewareDefinition): self
     {
         $route = clone $this;
-        $route->middlewareDefinitions[] = $middlewareDefinition;
+        $route->middlewares[] = $middlewareDefinition;
         $route->actionAdded = true;
         return $route;
     }
@@ -216,12 +202,12 @@ final class Route implements Stringable
      * It is useful to avoid invoking one of the parent group middleware for
      * a certain route.
      */
-    public function disableMiddleware(mixed ...$middlewareDefinition): self
+    public function disableMiddleware(mixed ...$definition): self
     {
         $route = clone $this;
         array_push(
-            $route->disabledMiddlewareDefinitions,
-            ...array_values($middlewareDefinition)
+            $route->disabledMiddlewares,
+            ...array_values($definition)
         );
         return $route;
     }
@@ -237,8 +223,8 @@ final class Route implements Stringable
      *           (T is 'hosts' ? array<array-key, string> :
      *               (T is 'methods' ? array<array-key,string> :
      *                   (T is 'defaults' ? array<string,string> :
-     *                       (T is ('override'|'hasMiddlewares'|'hasDispatcher') ? bool :
-     *                           (T is 'dispatcherWithMiddlewares' ? MiddlewareDispatcher : mixed)
+     *                       (T is ('override'|'hasMiddlewares') ? bool :
+     *                           (T is 'enabledMiddlewares' ? array<array-key,array|callable|string> : mixed)
      *                       )
      *                   )
      *               )
@@ -257,9 +243,8 @@ final class Route implements Stringable
             'methods' => $this->methods,
             'defaults' => $this->defaults,
             'override' => $this->override,
-            'dispatcherWithMiddlewares' => $this->getDispatcherWithMiddlewares(),
-            'hasMiddlewares' => $this->middlewareDefinitions !== [],
-            'hasDispatcher' => $this->dispatcher !== null,
+            'hasMiddlewares' => $this->middlewares !== [],
+            'enabledMiddlewares' => $this->getEnabledMiddlewares(),
             default => throw new InvalidArgumentException('Unknown data key: ' . $key),
         };
     }
@@ -297,31 +282,29 @@ final class Route implements Stringable
             'defaults' => $this->defaults,
             'override' => $this->override,
             'actionAdded' => $this->actionAdded,
-            'middlewareDefinitions' => $this->middlewareDefinitions,
-            'disabledMiddlewareDefinitions' => $this->disabledMiddlewareDefinitions,
-            'middlewareDispatcher' => $this->dispatcher,
+            'middlewares' => $this->middlewares,
+            'disabledMiddlewares' => $this->disabledMiddlewares,
+            'enabledMiddlewares' => $this->getEnabledMiddlewares(),
         ];
     }
 
-    private function getDispatcherWithMiddlewares(): MiddlewareDispatcher
+    /**
+     * @return array[]|callable[]|string[]
+     * @psalm-return list<array|callable|string>
+     */
+    private function getEnabledMiddlewares(): array
     {
-        if ($this->dispatcher === null) {
-            throw new RuntimeException(sprintf('There is no dispatcher in the route %s.', $this->getData('name')));
+        if ($this->enabledMiddlewares !== null) {
+            return $this->enabledMiddlewares;
         }
 
-        // Don't add middlewares to dispatcher if we did it earlier.
-        // This improves performance in event-loop applications.
-        if ($this->dispatcher->hasMiddlewares()) {
-            return $this->dispatcher;
-        }
+        $this->enabledMiddlewares = array_values(
+            array_filter(
+                $this->middlewares,
+                fn ($definition) => !in_array($definition, $this->disabledMiddlewares, true)
+            )
+        );
 
-        /** @var mixed $definition */
-        foreach ($this->middlewareDefinitions as $index => $definition) {
-            if (in_array($definition, $this->disabledMiddlewareDefinitions, true)) {
-                unset($this->middlewareDefinitions[$index]);
-            }
-        }
-
-        return $this->dispatcher = $this->dispatcher->withMiddlewares($this->middlewareDefinitions);
+        return $this->enabledMiddlewares;
     }
 }

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -104,12 +104,12 @@ final class RouteCollection implements RouteCollectionInterface
     {
         $prefix .= (string) $group->getData('prefix');
         $namePrefix .= (string) $group->getData('namePrefix');
-        $items = $group->getData('items');
+        $items = $group->getData('routes');
         $pattern = null;
         $hosts = [];
         foreach ($items as $item) {
             if (!$this->isStaticRoute($item)) {
-                $item = $item->prependMiddleware(...$group->getData('middlewareDefinitions'));
+                $item = $item->prependMiddleware(...$group->getData('enabledMiddlewares'));
             }
 
             if (!empty($group->getData('hosts')) && empty($item->getData('hosts'))) {

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -23,7 +23,6 @@ use Yiisoft\Router\Tests\Support\Container;
 use Yiisoft\Router\Tests\Support\TestMiddleware1;
 use Yiisoft\Router\Tests\Support\TestMiddleware2;
 use Yiisoft\Router\Tests\Support\TestMiddleware3;
-use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class GroupTest extends TestCase
 {
@@ -37,9 +36,9 @@ final class GroupTest extends TestCase
         $group = $group
             ->middleware($middleware1)
             ->middleware($middleware2);
-        $this->assertCount(2, $group->getData('middlewareDefinitions'));
-        $this->assertSame($middleware1, $group->getData('middlewareDefinitions')[0]);
-        $this->assertSame($middleware2, $group->getData('middlewareDefinitions')[1]);
+        $this->assertCount(2, $group->getData('enabledMiddlewares'));
+        $this->assertSame($middleware1, $group->getData('enabledMiddlewares')[0]);
+        $this->assertSame($middleware2, $group->getData('enabledMiddlewares')[1]);
     }
 
     public function testDisabledMiddlewareDefinitions(): void
@@ -49,19 +48,19 @@ final class GroupTest extends TestCase
             ->prependMiddleware(TestMiddleware1::class, TestMiddleware2::class)
             ->disableMiddleware(TestMiddleware1::class, TestMiddleware3::class);
 
-        $this->assertCount(1, $group->getData('middlewareDefinitions'));
-        $this->assertSame(TestMiddleware2::class, $group->getData('middlewareDefinitions')[0]);
+        $this->assertCount(1, $group->getData('enabledMiddlewares'));
+        $this->assertSame(TestMiddleware2::class, $group->getData('enabledMiddlewares')[0]);
     }
 
     public function testNamedArgumentsInMiddlewareMethods(): void
     {
         $group = Group::create()
-            ->middleware(middleware: TestMiddleware3::class)
-            ->prependMiddleware(middleware1: TestMiddleware1::class, middleware2: TestMiddleware2::class)
-            ->disableMiddleware(middleware1: TestMiddleware1::class, middleware2: TestMiddleware3::class);
+            ->middleware(TestMiddleware3::class)
+            ->prependMiddleware(TestMiddleware1::class, TestMiddleware2::class)
+            ->disableMiddleware(TestMiddleware1::class, TestMiddleware3::class);
 
-        $this->assertCount(1, $group->getData('middlewareDefinitions'));
-        $this->assertSame(TestMiddleware2::class, $group->getData('middlewareDefinitions')[0]);
+        $this->assertCount(1, $group->getData('enabledMiddlewares'));
+        $this->assertSame(TestMiddleware2::class, $group->getData('enabledMiddlewares')[0]);
     }
 
     public function testRoutesAfterMiddleware(): void
@@ -111,8 +110,8 @@ final class GroupTest extends TestCase
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('request1');
-        $response = $route
-            ->getData('dispatcherWithMiddlewares')
+        $response = $this->getDispatcher()
+            ->withMiddlewares($route->getData('enabledMiddlewares'))
             ->dispatch($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('middleware2', $response->getReasonPhrase());
@@ -132,7 +131,7 @@ final class GroupTest extends TestCase
             return $handler->handle($request);
         };
 
-        $group = Group::create('/group', $this->getDispatcher())
+        $group = Group::create('/group')
             ->middleware($middleware1)
             ->middleware($middleware2)
             ->routes(
@@ -146,9 +145,11 @@ final class GroupTest extends TestCase
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('request1');
-        $response = $route
-            ->getData('dispatcherWithMiddlewares')
+
+        $response = $this->getDispatcher()
+            ->withMiddlewares($route->getData('enabledMiddlewares'))
             ->dispatch($request, $this->getRequestHandler());
+
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('middleware2', $response->getReasonPhrase());
     }
@@ -161,7 +162,7 @@ final class GroupTest extends TestCase
         $middleware1 = fn () => new Response(403);
         $middleware2 = fn () => new Response(405);
 
-        $group = Group::create('/group', $this->getDispatcher())
+        $group = Group::create('/group')
             ->middleware($middleware1)
             ->middleware($middleware2)
             ->routes(
@@ -175,9 +176,11 @@ final class GroupTest extends TestCase
 
         $routeCollection = new RouteCollection($collector);
         $route = $routeCollection->getRoute('request1');
-        $response = $route
-            ->getData('dispatcherWithMiddlewares')
+
+        $response = $this->getDispatcher()
+            ->withMiddlewares($route->getData('enabledMiddlewares'))
             ->dispatch($request, $this->getRequestHandler());
+
         $this->assertSame(403, $response->getStatusCode());
     }
 
@@ -205,27 +208,27 @@ final class GroupTest extends TestCase
                     ),
             );
 
-        $this->assertCount(1, $root->getData('items'));
+        $this->assertCount(1, $root->getData('routes'));
 
         /** @var Group $api */
-        $api = $root->getData('items')[0];
+        $api = $root->getData('routes')[0];
 
         $this->assertSame('/api', $api->getData('prefix'));
-        $this->assertCount(2, $api->getData('items'));
-        $this->assertSame($logoutRoute, $api->getData('items')[0]);
+        $this->assertCount(2, $api->getData('routes'));
+        $this->assertSame($logoutRoute, $api->getData('routes')[0]);
 
         /** @var Group $postGroup */
-        $postGroup = $api->getData('items')[1];
+        $postGroup = $api->getData('routes')[1];
         $this->assertInstanceOf(Group::class, $postGroup);
-        $this->assertCount(2, $api->getData('middlewareDefinitions'));
-        $this->assertSame($middleware1, $api->getData('middlewareDefinitions')[0]);
-        $this->assertSame($middleware2, $api->getData('middlewareDefinitions')[1]);
+        $this->assertCount(2, $api->getData('enabledMiddlewares'));
+        $this->assertSame($middleware1, $api->getData('enabledMiddlewares')[0]);
+        $this->assertSame($middleware2, $api->getData('enabledMiddlewares')[1]);
 
         $this->assertSame('/post', $postGroup->getData('prefix'));
-        $this->assertCount(2, $postGroup->getData('items'));
-        $this->assertSame($listRoute, $postGroup->getData('items')[0]);
-        $this->assertSame($viewRoute, $postGroup->getData('items')[1]);
-        $this->assertEmpty($postGroup->getData('middlewareDefinitions'));
+        $this->assertCount(2, $postGroup->getData('routes'));
+        $this->assertSame($listRoute, $postGroup->getData('routes')[0]);
+        $this->assertSame($viewRoute, $postGroup->getData('routes')[1]);
+        $this->assertEmpty($postGroup->getData('enabledMiddlewares'));
     }
 
     public function testHost(): void
@@ -257,54 +260,6 @@ final class GroupTest extends TestCase
         $this->expectExceptionMessage('Unknown data key: wrong');
 
         $group->getData('wrong');
-    }
-
-    public function testDispatcherInjected(): void
-    {
-        $dispatcher = $this->getDispatcher();
-
-        $apiGroup = Group::create('/api', $dispatcher)
-            ->routes(
-                Route::get('/info')->name('api-info'),
-                Group::create('/v1')
-                    ->routes(
-                        Route::get('/user')->name('api-v1-user/index'),
-                        Route::get('/user/{id}')->name('api-v1-user/view'),
-                        Group::create('/news')
-                            ->routes(
-                                Route::get('/post')->name('api-v1-news-post/index'),
-                                Route::get('/post/{id}')->name('api-v1-news-post/view'),
-                            ),
-                        Group::create('/blog')
-                            ->routes(
-                                Route::get('/post')->name('api-v1-blog-post/index'),
-                                Route::get('/post/{id}')->name('api-v1-blog-post/view'),
-                            ),
-                        Route::get('/note')->name('api-v1-note/index'),
-                        Route::get('/note/{id}')->name('api-v1-note/view'),
-                    ),
-                Group::create('/v2')
-                    ->routes(
-                        Route::get('/user')->name('api-v2-user/index'),
-                        Route::get('/user/{id}')->name('api-v2-user/view'),
-                        Group::create('/news')
-                            ->routes(
-                                Route::get('/post')->name('api-v2-news-post/index'),
-                                Route::get('/post/{id}')->name('api-v2-news-post/view'),
-                                Group::create('/blog')
-                                    ->routes(
-                                        Route::get('/post')->name('api-v2-blog-post/index'),
-                                        Route::get('/post/{id}')->name('api-v2-blog-post/view'),
-                                        Route::get('/note')->name('api-v2-note/index'),
-                                        Route::get('/note/{id}')->name('api-v2-note/view')
-                                    )
-                            )
-                    )
-            );
-
-        $items = $apiGroup->getData('items');
-
-        $this->assertAllRoutesAndGroupsHaveDispatcher($items);
     }
 
     public function testWithCors(): void
@@ -440,15 +395,9 @@ final class GroupTest extends TestCase
 
     public function testImmutability(): void
     {
-        $container = new SimpleContainer();
-        $middlewareDispatcher = new MiddlewareDispatcher(
-            new MiddlewareFactory($container),
-        );
-
         $group = Group::create();
 
         $this->assertNotSame($group, $group->routes());
-        $this->assertNotSame($group, $group->withDispatcher($middlewareDispatcher));
         $this->assertNotSame($group, $group->withCors(null));
         $this->assertNotSame($group, $group->middleware());
         $this->assertNotSame($group, $group->prependMiddleware());
@@ -474,17 +423,5 @@ final class GroupTest extends TestCase
             new MiddlewareFactory($container),
             $this->createMock(EventDispatcherInterface::class)
         );
-    }
-
-    private function assertAllRoutesAndGroupsHaveDispatcher(array $items): void
-    {
-        $func = function ($item) use (&$func) {
-            $this->assertTrue($item->getData('hasDispatcher'));
-            if ($item instanceof Group) {
-                $items = $item->getData('items');
-                array_walk($items, $func);
-            }
-        };
-        array_walk($items, $func);
     }
 }

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -81,7 +81,7 @@ final class GroupTest extends TestCase
     {
         $request = new ServerRequest('GET', '/outergroup/innergroup/test1');
 
-        $action = static fn (ServerRequestInterface $request) => new Response(200, [], null, '1.1', implode($request->getAttributes()));
+        $action = static fn (ServerRequestInterface $request) => new Response(200, [], null, '1.1', implode('', $request->getAttributes()));
 
         $middleware1 = static function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             $request = $request->withAttribute('middleware', 'middleware1');
@@ -93,7 +93,7 @@ final class GroupTest extends TestCase
             return $handler->handle($request);
         };
 
-        $group = Group::create('/outergroup', $this->getDispatcher())
+        $group = Group::create('/outergroup')
             ->middleware($middleware1)
             ->routes(
                 Group::create('/innergroup')
@@ -121,7 +121,7 @@ final class GroupTest extends TestCase
     {
         $request = new ServerRequest('GET', '/group/test1');
 
-        $action = static fn (ServerRequestInterface $request) => new Response(200, [], null, '1.1', implode($request->getAttributes()));
+        $action = static fn (ServerRequestInterface $request) => new Response(200, [], null, '1.1', implode('', $request->getAttributes()));
         $middleware1 = function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             $request = $request->withAttribute('middleware', 'middleware1');
             return $handler->handle($request);

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -52,6 +52,52 @@ final class GroupTest extends TestCase
         $this->assertSame(TestMiddleware2::class, $group->getData('enabledMiddlewares')[0]);
     }
 
+    public function testPrependMiddlewaresAfterGetEnabledMiddlewares(): void
+    {
+        $group = Group::create()
+            ->middleware(TestMiddleware3::class)
+            ->disableMiddleware(TestMiddleware1::class);
+
+        $group->getData('enabledMiddlewares');
+
+        $group = $group->prependMiddleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $this->assertSame(
+            [TestMiddleware2::class, TestMiddleware3::class],
+            $group->getData('enabledMiddlewares')
+        );
+    }
+
+    public function testAddMiddlewareAfterGetEnabledMiddlewares(): void
+    {
+        $group = Group::create()
+            ->middleware(TestMiddleware3::class);
+
+        $group->getData('enabledMiddlewares');
+
+        $group = $group->middleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $this->assertSame(
+            [TestMiddleware3::class, TestMiddleware1::class,  TestMiddleware2::class],
+            $group->getData('enabledMiddlewares')
+        );
+    }
+
+    public function testDisableMiddlewareAfterGetEnabledMiddlewares(): void
+    {
+        $group = Group::create()
+            ->middleware(TestMiddleware1::class, TestMiddleware2::class, TestMiddleware3::class);
+
+        $group->getData('enabledMiddlewares');
+
+        $group = $group->disableMiddleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $this->assertSame(
+            [TestMiddleware3::class],
+            $group->getData('enabledMiddlewares')
+        );
+    }
+
     public function testMiddlewaresWithKeys(): void
     {
         $group = Group::create()

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -52,6 +52,19 @@ final class GroupTest extends TestCase
         $this->assertSame(TestMiddleware2::class, $group->getData('enabledMiddlewares')[0]);
     }
 
+    public function testMiddlewaresWithKeys(): void
+    {
+        $group = Group::create()
+            ->middleware(m3: TestMiddleware3::class)
+            ->prependMiddleware(m1: TestMiddleware1::class, m2: TestMiddleware2::class)
+            ->disableMiddleware(m1: TestMiddleware1::class);
+
+        $this->assertSame(
+            [TestMiddleware2::class, TestMiddleware3::class],
+            $group->getData('enabledMiddlewares')
+        );
+    }
+
     public function testNamedArgumentsInMiddlewareMethods(): void
     {
         $group = Group::create()

--- a/tests/MatchingResultTest.php
+++ b/tests/MatchingResultTest.php
@@ -4,21 +4,11 @@ declare(strict_types=1);
 
 namespace Yiisoft\Router\Tests;
 
-use Nyholm\Psr7\Response;
-use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
-use Psr\EventDispatcher\EventDispatcherInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use Yiisoft\Http\Method;
-use Yiisoft\Middleware\Dispatcher\MiddlewareDispatcher;
-use Yiisoft\Middleware\Dispatcher\MiddlewareFactory;
 use Yiisoft\Router\MatchingResult;
 use Yiisoft\Router\Route;
-use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class MatchingResultTest extends TestCase
 {
@@ -48,31 +38,6 @@ final class MatchingResultTest extends TestCase
         $this->assertFalse($result->isMethodFailure());
     }
 
-    public function testProcessSuccess(): void
-    {
-        $container = $this->createMock(ContainerInterface::class);
-        $dispatcher = new MiddlewareDispatcher(
-            new MiddlewareFactory($container),
-            $this->createMock(EventDispatcherInterface::class)
-        );
-        $route = Route::post('/', $dispatcher)->middleware($this->getMiddleware());
-        $result = MatchingResult::fromSuccess($route, []);
-        $request = new ServerRequest('POST', '/');
-
-        $response = $result->process($request, $this->getRequestHandler());
-        $this->assertSame(201, $response->getStatusCode());
-    }
-
-    public function testProcessFailure(): void
-    {
-        $request = new ServerRequest('POST', '/');
-
-        $response = MatchingResult::fromFailure([Method::GET, Method::HEAD])
-            ->process($request, $this->getRequestHandler());
-
-        $this->assertSame(404, $response->getStatusCode());
-    }
-
     public function testRouteOnFailure(): void
     {
         $result = MatchingResult::fromFailure([Method::GET, Method::HEAD]);
@@ -80,32 +45,5 @@ final class MatchingResultTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('There is no route in the matching result.');
         $result->route();
-    }
-
-    public function testImmutability(): void
-    {
-        $container = new SimpleContainer();
-        $middlewareDispatcher = new MiddlewareDispatcher(
-            new MiddlewareFactory($container),
-        );
-
-        $result = MatchingResult::fromFailure([Method::GET]);
-
-        $this->assertNotSame($result, $result->withDispatcher($middlewareDispatcher));
-    }
-
-    private function getMiddleware(): callable
-    {
-        return static fn () => new Response(201);
-    }
-
-    private function getRequestHandler(): RequestHandlerInterface
-    {
-        return new class () implements RequestHandlerInterface {
-            public function handle(ServerRequestInterface $request): ResponseInterface
-            {
-                return new Response(404);
-            }
-        };
     }
 }

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -97,7 +97,7 @@ final class RouteCollectionTest extends TestCase
         $group = Group::create()
             ->middleware(fn () => 1)
             ->routes(
-                Route::get('/test', $this->getDispatcher())
+                Route::get('/test')
                     ->action(fn () => 2)
                     ->name('test'),
                 Route::get('/images/{sile}')->name('image')
@@ -115,19 +115,19 @@ final class RouteCollectionTest extends TestCase
     {
         $group1 = Group::create('/api')
             ->routes(
-                Route::get('/test', $this->getDispatcher())
+                Route::get('/test')
                     ->action(fn () => 2)
                     ->name('/test'),
                 Route::get('/images/{sile}')->name('/image'),
                 Group::create('/v1')
                     ->routes(
-                        Route::get('/posts', $this->getDispatcher())->name('/posts'),
+                        Route::get('/posts')->name('/posts'),
                         Route::get('/post/{sile}')->name('/post/view')
                     )
                     ->namePrefix('/v1'),
                 Group::create('/v1')
                     ->routes(
-                        Route::get('/tags', $this->getDispatcher())->name('/tags'),
+                        Route::get('/tags')->name('/tags'),
                         Route::get('/tag/{slug}')->name('/tag/view'),
                     )
                     ->namePrefix('/v1'),
@@ -135,7 +135,7 @@ final class RouteCollectionTest extends TestCase
 
         $group2 = Group::create('/api')
             ->routes(
-                Route::get('/posts', $this->getDispatcher())->name('/posts'),
+                Route::get('/posts')->name('/posts'),
                 Route::get('/post/{sile}')->name('/post/view'),
             )
             ->namePrefix('/api');
@@ -168,7 +168,7 @@ final class RouteCollectionTest extends TestCase
         $group = Group::create()
             ->middleware(fn () => 1)
             ->routes(
-                Route::get('/test', $this->getDispatcher())
+                Route::get('/test')
                     ->action(fn () => 2)
                     ->name('test'),
                 Route::get('/images/{sile}')->name('image')
@@ -252,16 +252,16 @@ final class RouteCollectionTest extends TestCase
             [],
             null,
             '1.1',
-            implode($request->getAttributes())
+            implode('', $request->getAttributes())
         );
         $listRoute = Route::get('/')
             ->action($action)
             ->name('list');
-        $viewRoute = Route::get('/{id}', $this->getDispatcher())
+        $viewRoute = Route::get('/{id}')
             ->action($action)
             ->name('view');
 
-        $group = Group::create(null, $this->getDispatcher())->routes($listRoute);
+        $group = Group::create(null)->routes($listRoute);
 
         $middleware = function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             $request = $request->withAttribute('middleware', 'middleware1');

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -298,9 +298,56 @@ final class RouteTest extends TestCase
         $this->assertSame('123', (string) $response->getBody());
     }
 
+    public function testPrependMiddlewaresAfterGetEnabledMiddlewares(): void
+    {
+        $route = Route::get('/')
+            ->middleware(TestMiddleware3::class)
+            ->disableMiddleware(TestMiddleware1::class)
+            ->action([TestController::class, 'index']);
+
+        $route->getData('enabledMiddlewares');
+
+        $route = $route->prependMiddleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $this->assertSame(
+            [TestMiddleware2::class, TestMiddleware3::class, [TestController::class, 'index']],
+            $route->getData('enabledMiddlewares')
+        );
+    }
+
+    public function testAddMiddlewareAfterGetEnabledMiddlewares(): void
+    {
+        $route = Route::get('/')
+            ->middleware(TestMiddleware3::class);
+
+        $route->getData('enabledMiddlewares');
+
+        $route = $route->middleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $this->assertSame(
+            [TestMiddleware3::class, TestMiddleware1::class,  TestMiddleware2::class],
+            $route->getData('enabledMiddlewares')
+        );
+    }
+
+    public function testDisableMiddlewareAfterGetEnabledMiddlewares(): void
+    {
+        $route = Route::get('/')
+            ->middleware(TestMiddleware1::class, TestMiddleware2::class, TestMiddleware3::class);
+
+        $route->getData('enabledMiddlewares');
+
+        $route = $route->disableMiddleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $this->assertSame(
+            [TestMiddleware3::class],
+            $route->getData('enabledMiddlewares')
+        );
+    }
+
     public function testMiddlewaresWithKeys(): void
     {
-        $group = Route::get('/')
+        $route = Route::get('/')
             ->middleware(m3: TestMiddleware3::class)
             ->action([TestController::class, 'index'])
             ->prependMiddleware(m1: TestMiddleware1::class, m2: TestMiddleware2::class)
@@ -308,7 +355,7 @@ final class RouteTest extends TestCase
 
         $this->assertSame(
             [TestMiddleware2::class, TestMiddleware3::class, [TestController::class, 'index']],
-            $group->getData('enabledMiddlewares')
+            $route->getData('enabledMiddlewares')
         );
     }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -220,12 +220,14 @@ final class RouteTest extends TestCase
                 TestController::class => new TestController(),
             ]
         );
-        $dispatcher = $this->getDispatcher($container);
+
         $route = Route::get('/')->action([TestController::class, 'index']);
-        $route->injectDispatcher($dispatcher);
-        $response = $route
-            ->getData('dispatcherWithMiddlewares')
+
+        $response = $this
+            ->getDispatcher($container)
+            ->withMiddlewares($route->getData('enabledMiddlewares'))
             ->dispatch($request, $this->getRequestHandler());
+
         $this->assertSame(200, $response->getStatusCode());
     }
 
@@ -251,22 +253,21 @@ final class RouteTest extends TestCase
     {
         $request = new ServerRequest('GET', '/');
 
-        $injectDispatcher = $this->getDispatcher(
-            $this->getContainer([
-                TestMiddleware1::class => new TestMiddleware1(),
-                TestMiddleware2::class => new TestMiddleware2(),
-                TestMiddleware3::class => new TestMiddleware3(),
-                TestController::class => new TestController(),
-            ])
-        );
-
         $route = Route::get('/')
             ->middleware(TestMiddleware1::class, TestMiddleware2::class, TestMiddleware3::class)
             ->action([TestController::class, 'index'])
             ->disableMiddleware(TestMiddleware1::class, TestMiddleware3::class);
-        $route->injectDispatcher($injectDispatcher);
 
-        $dispatcher = $route->getData('dispatcherWithMiddlewares');
+        $dispatcher = $this
+            ->getDispatcher(
+                $this->getContainer([
+                    TestMiddleware1::class => new TestMiddleware1(),
+                    TestMiddleware2::class => new TestMiddleware2(),
+                    TestMiddleware3::class => new TestMiddleware3(),
+                    TestController::class => new TestController(),
+                ])
+            )
+            ->withMiddlewares($route->getData('enabledMiddlewares'));
 
         $response = $dispatcher->dispatch($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
@@ -277,63 +278,25 @@ final class RouteTest extends TestCase
     {
         $request = new ServerRequest('GET', '/');
 
-        $injectDispatcher = $this->getDispatcher(
-            $this->getContainer([
-                TestMiddleware1::class => new TestMiddleware1(),
-                TestMiddleware2::class => new TestMiddleware2(),
-                TestMiddleware3::class => new TestMiddleware3(),
-                TestController::class => new TestController(),
-            ])
-        );
-
         $route = Route::get('/')
             ->middleware(TestMiddleware3::class)
             ->action([TestController::class, 'index'])
             ->prependMiddleware(TestMiddleware1::class, TestMiddleware2::class);
-        $route->injectDispatcher($injectDispatcher);
 
-        $dispatcher = $route->getData('dispatcherWithMiddlewares');
-
-        $response = $dispatcher->dispatch($request, $this->getRequestHandler());
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('123', (string) $response->getBody());
-    }
-
-    public function testGetDispatcherWithoutDispatcher(): void
-    {
-        $route = Route::get('/')->name('test');
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('There is no dispatcher in the route test.');
-        $route->getData('dispatcherWithMiddlewares');
-    }
-
-    public function testGetDispatcherWithMiddlewares(): void
-    {
-        $request = new ServerRequest('GET', '/');
-
-        $injectDispatcher = $this
+        $response = $this
             ->getDispatcher(
                 $this->getContainer([
                     TestMiddleware1::class => new TestMiddleware1(),
                     TestMiddleware2::class => new TestMiddleware2(),
+                    TestMiddleware3::class => new TestMiddleware3(),
                     TestController::class => new TestController(),
                 ])
             )
-            ->withMiddlewares([
-                TestMiddleware1::class,
-                TestMiddleware2::class,
-                [TestController::class, 'index'],
-            ]);
+            ->withMiddlewares($route->getData('enabledMiddlewares'))
+            ->dispatch($request, $this->getRequestHandler());
 
-        $route = Route::get('/');
-        $route->injectDispatcher($injectDispatcher);
-
-        $dispatcher = $route->getData('dispatcherWithMiddlewares');
-
-        $response = $dispatcher->dispatch($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('12', (string) $response->getBody());
+        $this->assertSame('123', (string) $response->getBody());
     }
 
     public function testDebugInfo(): void
@@ -343,10 +306,10 @@ final class RouteTest extends TestCase
             ->host('example.com')
             ->defaults(['age' => 42])
             ->override()
-            ->middleware(middleware: TestMiddleware1::class)
-            ->disableMiddleware(middleware: TestMiddleware2::class)
+            ->middleware(TestMiddleware1::class, TestMiddleware2::class)
+            ->disableMiddleware(TestMiddleware2::class)
             ->action('go')
-            ->prependMiddleware(middleware: TestMiddleware3::class);
+            ->prependMiddleware(TestMiddleware3::class);
 
         $expected = <<<EOL
 Yiisoft\Router\Route Object
@@ -370,19 +333,25 @@ Yiisoft\Router\Route Object
 
     [override] => 1
     [actionAdded] => 1
-    [middlewareDefinitions] => Array
+    [middlewares] => Array
+        (
+            [0] => Yiisoft\Router\Tests\Support\TestMiddleware3
+            [1] => Yiisoft\Router\Tests\Support\TestMiddleware1
+            [2] => Yiisoft\Router\Tests\Support\TestMiddleware2
+            [3] => go
+        )
+
+    [disabledMiddlewares] => Array
+        (
+            [0] => Yiisoft\Router\Tests\Support\TestMiddleware2
+        )
+
+    [enabledMiddlewares] => Array
         (
             [0] => Yiisoft\Router\Tests\Support\TestMiddleware3
             [1] => Yiisoft\Router\Tests\Support\TestMiddleware1
             [2] => go
         )
-
-    [disabledMiddlewareDefinitions] => Array
-        (
-            [0] => Yiisoft\Router\Tests\Support\TestMiddleware2
-        )
-
-    [middlewareDispatcher] =>
 )
 
 EOL;
@@ -399,15 +368,9 @@ EOL;
 
     public function testImmutability(): void
     {
-        $container = new SimpleContainer();
-        $middlewareDispatcher = new MiddlewareDispatcher(
-            new MiddlewareFactory($container),
-        );
-
         $route = Route::get('/');
         $routeWithAction = $route->action('');
 
-        $this->assertNotSame($route, $route->withDispatcher($middlewareDispatcher));
         $this->assertNotSame($route, $route->name(''));
         $this->assertNotSame($route, $route->pattern(''));
         $this->assertNotSame($route, $route->host(''));

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -298,6 +298,20 @@ final class RouteTest extends TestCase
         $this->assertSame('123', (string) $response->getBody());
     }
 
+    public function testMiddlewaresWithKeys(): void
+    {
+        $group = Route::get('/')
+            ->middleware(m3: TestMiddleware3::class)
+            ->action([TestController::class, 'index'])
+            ->prependMiddleware(m1: TestMiddleware1::class, m2: TestMiddleware2::class)
+            ->disableMiddleware(m1: TestMiddleware1::class);
+
+        $this->assertSame(
+            [TestMiddleware2::class, TestMiddleware3::class, [TestController::class, 'index']],
+            $group->getData('enabledMiddlewares')
+        );
+    }
+
     public function testDebugInfo(): void
     {
         $route = Route::get('/')

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -345,6 +345,18 @@ final class RouteTest extends TestCase
         );
     }
 
+    public function testGetEnabledMiddlewaresTwice(): void
+    {
+        $route = Route::get('/')
+            ->middleware(TestMiddleware1::class, TestMiddleware2::class);
+
+        $result1 = $route->getData('enabledMiddlewares');
+        $result2 = $route->getData('enabledMiddlewares');
+
+        $this->assertSame([TestMiddleware1::class, TestMiddleware2::class], $result1);
+        $this->assertSame($result1, $result2);
+    }
+
     public function testMiddlewaresWithKeys(): void
     {
         $route = Route::get('/')

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -23,7 +23,6 @@ use Yiisoft\Router\Tests\Support\TestMiddleware1;
 use Yiisoft\Router\Tests\Support\TestMiddleware2;
 use Yiisoft\Router\Tests\Support\TestController;
 use Yiisoft\Router\Tests\Support\TestMiddleware3;
-use Yiisoft\Test\Support\Container\SimpleContainer;
 
 final class RouteTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -

Extracted from #196 
