### PR TITLE
Mark `Group::create`, `RouteCollectorInterface`, `RouteCollector`, and `Route` HTTP methods as deprecated

### DIFF
--- a/src/Group.php
+++ b/src/Group.php
@@ -74,6 +74,8 @@ final class Group
      * Create a new group instance.
      *
      * @param string|null $prefix URL prefix to prepend to all routes of the group.
+     *
+     * @deprecated Use `new Group()` instead.
      */
     public static function create(?string $prefix = null): self
     {

--- a/src/Route.php
+++ b/src/Route.php
@@ -139,6 +139,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function get(string $pattern): self
     {
@@ -150,6 +152,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function post(string $pattern): self
     {
@@ -161,6 +165,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function put(string $pattern): self
     {
@@ -172,6 +178,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function delete(string $pattern): self
     {
@@ -183,6 +191,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function patch(string $pattern): self
     {
@@ -194,6 +204,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function head(string $pattern): self
     {
@@ -205,6 +217,8 @@ final class Route implements Stringable
      *
      * @param string $pattern URL pattern.
      * @return self New route instance.
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function options(string $pattern): self
     {
@@ -213,6 +227,8 @@ final class Route implements Stringable
 
     /**
      * @param string[] $methods
+     *
+     * @deprecated Use `new Router()` instead.
      */
     public static function methods(array $methods, string $pattern): self
     {

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -8,6 +8,8 @@ use Yiisoft\Router\Provider\RoutesProviderInterface;
 
 /**
  * Simple route collector that manages routes, groups, and middleware definitions.
+ *
+ * @deprecated Will be removed in the next major release.
  */
 final class RouteCollector implements RouteCollectorInterface
 {

--- a/src/RouteCollectorInterface.php
+++ b/src/RouteCollectorInterface.php
@@ -6,6 +6,8 @@ namespace Yiisoft\Router;
 
 /**
  * Interface for route collectors that manage route registration.
+ *
+ * @deprecated Will be removed in the next major release.
  */
 interface RouteCollectorInterface
 {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
