### PR TITLE
Allow to use backed enumerations as route name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.0.3 under development
 
+- New #280: Allow to use backed enumerations as route name in `Route::name()` (@KalimeroMK)
 - Enh #276, #292: Explicitly import classes, functions, and constants in the "use" section (@rustamwin, @vjik)
 - Enh #277, #281: Remove restrictions from `prependMiddleware()` and `middleware()` methods (@klsoft-web, @vjik)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ Route::methods([Method::GET, Method::POST], '/page/add')
 The enumeration is resolved to its backing value right away, so the route name is still the string `page-add`. Pass
 that string where a route name is expected, for example `$urlGenerator->generate(RouteName::PageAdd->value)`.
 
-`action()` in the above is a primary middleware definition that is invoked last when matching result `process()`
 The `action` argument is a primary middleware definition that is invoked last when matching result `process()`
 method is called. How middleware are executed and what middleware formats are accepted is defined by middleware
 dispatcher used. See [readme of yiisoft/middleware-dispatcher](https://github.com/yiisoft/middleware-dispatcher)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,25 @@ Route::methods([Method::GET, Method::POST], '/page/add')
 If you want to generate a URL based on route and its parameters, give it a name with `name()`. Check "Creating URLs"
 for details.
 
+Besides a string, `name()` also accepts a backed enumeration. That lets you keep route names in a single place and
+refer to them in a type-safe way:
+
+```php
+use Yiisoft\Router\Route;
+
+enum RouteName: string
+{
+    case PageAdd = 'page-add';
+}
+
+Route::methods([Method::GET, Method::POST], '/page/add')
+    ->name(RouteName::PageAdd)
+    ->action([PageController::class, 'actionAdd']);
+```
+
+The enumeration is resolved to its backing value right away, so the route name is still the string `page-add`. Pass
+that string where a route name is expected, for example `$urlGenerator->generate(RouteName::PageAdd->value)`.
+
 `action()` in the above is a primary middleware definition that is invoked last when matching result `process()`
 method is called. How middleware are executed and what middleware formats are accepted is defined by middleware
 dispatcher used. See [readme of yiisoft/middleware-dispatcher](https://github.com/yiisoft/middleware-dispatcher)

--- a/src/Route.php
+++ b/src/Route.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Router;
 
+use BackedEnum;
 use InvalidArgumentException;
 use Stringable;
 use Yiisoft\Http\Method;
@@ -136,10 +137,14 @@ final class Route implements Stringable
         return new self($methods, $pattern);
     }
 
-    public function name(string $name): self
+    /**
+     * @param string|BackedEnum $name Name of the route. A backed enumeration is resolved to its backing value, so
+     * the route name is still a string afterwards.
+     */
+    public function name(string|BackedEnum $name): self
     {
         $route = clone $this;
-        $route->name = $name;
+        $route->name = $name instanceof BackedEnum ? (string) $name->value : $name;
         return $route;
     }
 

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -123,9 +123,7 @@ final class RouteCollection implements RouteCollectionInterface
                     continue;
                 }
                 /** @psalm-suppress PossiblyNullArrayOffset Checked group prefix on not empty above. */
-                if (!isset($tree[$item->getData('prefix')])) {
-                    $tree[$item->getData('prefix')] = [];
-                }
+                $tree[$item->getData('prefix')] ??= [];
                 /**
                  * @psalm-suppress MixedArgumentTypeCoercion
                  * @psalm-suppress MixedArgument,PossiblyNullArrayOffset

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -19,10 +19,12 @@ use Yiisoft\Middleware\Dispatcher\MiddlewareFactory;
 use Yiisoft\Router\Route;
 use Yiisoft\Router\Tests\Support\AssertTrait;
 use Yiisoft\Router\Tests\Support\Container;
+use Yiisoft\Router\Tests\Support\IntTestRouteName;
 use Yiisoft\Router\Tests\Support\TestMiddleware1;
 use Yiisoft\Router\Tests\Support\TestMiddleware2;
 use Yiisoft\Router\Tests\Support\TestController;
 use Yiisoft\Router\Tests\Support\TestMiddleware3;
+use Yiisoft\Router\Tests\Support\TestRouteName;
 use InvalidArgumentException;
 
 final class RouteTest extends TestCase
@@ -34,6 +36,28 @@ final class RouteTest extends TestCase
         $route = Route::get('/')->name('test.route');
 
         $this->assertSame('test.route', $route->getData('name'));
+    }
+
+    public function testNameFromBackedEnum(): void
+    {
+        $route = Route::get('/')->name(TestRouteName::Home);
+
+        $this->assertSame('home', $route->getData('name'));
+    }
+
+    public function testNameFromIntBackedEnum(): void
+    {
+        $route = Route::get('/')->name(IntTestRouteName::About);
+
+        $this->assertSame('2', $route->getData('name'));
+    }
+
+    public function testNameFromBackedEnumIsInterchangeableWithString(): void
+    {
+        $this->assertSame(
+            Route::get('/')->name('home')->getData('name'),
+            Route::get('/')->name(TestRouteName::Home)->getData('name'),
+        );
     }
 
     public function testNameDefault(): void

--- a/tests/Support/IntTestRouteName.php
+++ b/tests/Support/IntTestRouteName.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Router\Tests\Support;
+
+enum IntTestRouteName: int
+{
+    case Home = 1;
+    case About = 2;
+}

--- a/tests/Support/TestRouteName.php
+++ b/tests/Support/TestRouteName.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Router\Tests\Support;
+
+enum TestRouteName: string
+{
+    case Home = 'home';
+    case About = 'about';
+}


### PR DESCRIPTION
Fixes #280.

`Route::name()` now accepts a backed enumeration in addition to a string. The enumeration is resolved to its backing value immediately, so route names are still stored and returned as strings.

`Route` is final and `name()` is not part of any interface, so there are no interface changes, no BC baseline entries and no `yiisoft/router-implementation` bump.

Widening the route name in `RouteCollectionInterface` and `UrlGeneratorInterface` is deliberately left out: it is not BC for classes implementing them and needs a coordinated `dummy-provider` + `router-fastroute` + `router` release. Discussed in #280.

`RouteCollection.php` is the only unrelated change — Rector rewrites that line on every run, and applying it keeps `rector-cs` from committing it.
